### PR TITLE
assert_raises should ignore MiniTest::Skip

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -216,6 +216,8 @@ module MiniTest
       begin
         yield
         should_raise = true
+      rescue MiniTest::Skip
+        raise
       rescue Exception => e
         details = "#{msg}#{mu_pp(exp)} exception expected, not"
         assert(exp.any? { |ex|


### PR DESCRIPTION
Hi.

I encountered a situation where a skip occurs inside of assert_raises block, and the MiniTest::Skip exception was catched by that assert_raises.  But I think a skip should propagate out of the assertion.  Can you pull this?
