### PR TITLE
assert_match fix

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -439,7 +439,6 @@ module MiniTest
 
     def refute_match exp, act, msg = nil
       msg = message(msg) { "Expected #{mu_pp(exp)} to not match #{mu_pp(act)}" }
-      assert_respond_to act, :"=~"
       exp = (/#{Regexp.escape exp}/) if String === exp and String === act
       refute exp =~ act, msg
     end


### PR DESCRIPTION
Due to the fact that assert_match uses assert_respond_to the number of assertions being run is artificially being increased to represent one of the actual assertion and one for checking if the object responds to =~. There should be no case where something doesn't respond to =~ so there is no point in testing it and the number of assertions should not be incremented for testing to make sure that the test is valid. The test should simply fail if it is not a valid test.
