### PR TITLE
Failure message contain describe text

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -60,10 +60,12 @@ module Kernel
 
   def describe desc, &block
     stack = MiniTest::Spec.describe_stack
-    name  = desc.to_s.split(/\W+/).map { |s| s.capitalize }.join + "Spec"
     prev  = stack.last
-    name  = "#{prev == MiniTest::Spec ? nil : prev}::#{name}"
-    cls   = Object.class_eval "class #{name} < #{prev}; end; #{name}"
+    name  = "#{prev == MiniTest::Spec ? nil : prev}::#{desc}"
+    cls   = Class.new(prev)
+    (class << cls; self; end).class_eval do
+      define_method(:to_s) {name}
+    end    
 
     cls.nuke_test_methods!
 

--- a/test/test_mini_spec.rb
+++ b/test/test_mini_spec.rb
@@ -197,7 +197,7 @@ end
 
 class TestMeta < MiniTest::Unit::TestCase
   def test_structure
-    x = y = nil
+    x = y = z = nil
     x = describe "top-level thingy" do
       before {}
       after  {}
@@ -208,6 +208,11 @@ class TestMeta < MiniTest::Unit::TestCase
         before {}
         it "inner-it" do end
       end
+
+      z = describe "inner thingy" do
+        before {}
+        it "inner-it" do end
+      end
     end
 
     top_methods = %w(setup teardown test_0001_top_level_it)
@@ -215,5 +220,6 @@ class TestMeta < MiniTest::Unit::TestCase
 
     assert_equal top_methods, x.instance_methods(false).sort.map   {|o| o.to_s }
     assert_equal inner_methods, y.instance_methods(false).sort.map {|o| o.to_s }
+    assert_equal inner_methods, z.instance_methods(false).sort.map {|o| o.to_s }
   end
 end


### PR DESCRIPTION
This was originally http://github.com/seattlerb/minitest/pull/4

I anonimized the Spec classes and overrode .to_s on them to return the given text of the describe argument.

I could also define name= on the class object. That would remove the need to use the (class << self; self; end) closure to define to_s.

The benefit is the error output shows the exact text of the describe blocks. A number of people have naming conventions that use non-alphanumeric characters in the describe text. These characters would be lost with the camel-cased class names.

Do you have any apprehensions against this approach?
