### PR TITLE
Added parallel support

### DIFF
--- a/test_concurrent.rb
+++ b/test_concurrent.rb
@@ -1,0 +1,35 @@
+require 'minitest/unit'
+require 'rubygems'
+require 'parallel'
+
+class ConcurrentTestOne < MiniTest::Unit::TestCase
+  def test_sleep_one
+    sleep(2)
+    assert true
+  end
+end
+class ConcurrentTestTwo < MiniTest::Unit::TestCase
+  def test_sleep_two
+    sleep(2)
+    assert true
+  end
+  def test_something_else
+    assert true
+  end
+  def test_a_third_thing
+    assert true
+  end
+end
+class ConcurrentTestThree < MiniTest::Unit::TestCase
+  def test_sleep_three
+    sleep(2)
+  end
+end
+
+start = Time.now
+MiniTest::Unit.new.run ['-p 4']
+finish = Time.now
+
+if finish - start > 2.5
+  raise "Not in parallel!"
+end


### PR DESCRIPTION
Hey guys,

Loving minitest so far! I've added parallel support to minitest via the parallel gem. The parallel gem is not required unless you actually try to run in parallel, so normal users won't have to worry about it.

I added it in as a "-p PROCS" switch to the command line args.

I'm ashamed to say the test I wrote is pretty crappy. I put it under the root directory because it doesn't run as part of the suite :-/

To test it out, run:

ruby -Ilib concurrent_test.rb -p 4

that will pass. But if you run:

ruby -Ilib concurrent_test.rb

it will raise and exception.

The only way I could think of incorporating it into the test suite would be to add some test files in a fixtures directory, then shell out to minitest and see that they complete in a certain amount of time. This would slow the test suite down a lot though, and it's really fast right now.

So, any thoughts? Areas to improve?

Thanks again for minitest!

-Nick Gauthier (@ngauthier)
