### PR TITLE
teardown calls should be dispatched in reverse order

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -134,17 +134,16 @@ class MiniTest::Spec < MiniTest::Unit::TestCase
   def self.define_inheritable_method name, &block # :nodoc:
     super_method = self.superclass.instance_method name
 
-    case name.to_sym
-      when :teardown
-        define_method(name) do
-          instance_eval(&block)
-          super_method.bind(self).call if super_method
-        end
-      else
-        define_method(name) do
-          super_method.bind(self).call if super_method
-          instance_eval(&block)
-        end
+    if name.to_sym == :teardown
+      define_method(name) do
+        instance_eval(&block)
+        super_method.bind(self).call if super_method
+      end
+    else
+      define_method(name) do
+        super_method.bind(self).call if super_method
+        instance_eval(&block)
+      end
     end
   end
 

--- a/test/test_minitest_spec.rb
+++ b/test/test_minitest_spec.rb
@@ -1,4 +1,5 @@
 require 'minitest/spec'
+require 'stringio'
 
 MiniTest::Unit.autorun
 
@@ -230,16 +231,15 @@ class TestMeta < MiniTest::Unit::TestCase
     assert_equal inner_methods, y.instance_methods(false).sort.map {|o| o.to_s }
     assert_equal inner_methods, z.instance_methods(false).sort.map {|o| o.to_s }
 
-    File.open('/dev/null', 'w') do |file|
-      MiniTest::Unit.output = file
-      z.new(nil).run(MiniTest::Unit.new)
-    end
+    orig_stdout           = MiniTest::Unit.output
+    MiniTest::Unit.output = StringIO.new
+    z.new(nil).run(MiniTest::Unit.new)
 
     assert_equal [1, 2, 3], before_list
     assert_equal [3, 2, 1], after_list
 
     ensure
-      MiniTest::Unit.output = $stdout
+      MiniTest::Unit.output = orig_stdout
   end
 
   def test_structure_subclasses


### PR DESCRIPTION
this ensures teardown can dispose allocated resources in the correct order (if such resources are needed deeper in the hierarchy in other teardown calls)
