### PR TITLE
Add error messages to Mock#method_missing

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -45,8 +45,9 @@ module MiniTest
     end
 
     def method_missing(sym, *args) # :nodoc:
-      raise NoMethodError unless @expected_calls.has_key?(sym)
-      raise ArgumentError unless @expected_calls[sym][:args].size == args.size
+      raise NoMethodError, sym.to_s unless @expected_calls.has_key?(sym)
+      msg = "#{sym} expected #{@expected_calls[sym][:args].size} arguments, received #{args.size}"
+      raise ArgumentError, msg unless @expected_calls[sym][:args].size == args.size
       retval = @expected_calls[sym][:retval]
       @actual_calls[sym] << { :retval => retval, :args => args }
       retval


### PR DESCRIPTION
I added error messages to the exceptions in method_missing to make debugging test failures easier. Prior to this change the error messages read "NoMethodError: NoMethodError" and "ArgumentError: ArgumentError."  Now they read "NoMethodError: my_method_name" and "ArgumentError: my_method_name expected 2 arguments, received 0."

What do you guys think of this change?
