### PR TITLE
Adding -f option: stop after first failure or error

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -765,7 +765,7 @@ module MiniTest
       suites.each do |suite|
         results << _run_suite(suite, type)
         if options[:stop_on_failure] && failure_or_error
-          puts "\n\n# Stopping early due to test failure or error."
+          print "\n\n# Stopping early due to test failure or error."
           break
         end
       end

--- a/test/test_minitest_unit.rb
+++ b/test/test_minitest_unit.rb
@@ -436,6 +436,47 @@ Finished tests in 0.00
     assert_report expected
   end
 
+  def test_stop_on_failure
+    tc = Class.new(MiniTest::Unit::TestCase) do
+      def self.test_order
+        :alpha
+      end
+
+      def test_something_1
+        assert true
+      end
+
+      def test_something_2
+        assert false
+      end
+
+      def test_something_3
+        assert false
+      end
+    end
+
+    Object.const_set(:ATestCase, tc)
+    @tu.run %w[--seed 42 --stop-on-failure]
+
+    expected = "Run options: --seed 42 --stop-on-failure
+
+# Running tests:
+
+.F
+
+# Stopping early due to test failure or error.
+
+Finished tests in 0.00
+
+  1) Failure:
+test_something_2(ATestCase) [FILE:LINE]:
+Failed assertion, no message given.
+
+2 tests, 2 assertions, 1 failures, 0 errors, 0 skips
+"
+    assert_report expected
+  end
+
   def util_expand_bt bt
     if RUBY_VERSION =~ /^1\.9/ then
       bt.map { |f| (f =~ /^\./) ? File.expand_path(f) : f }


### PR DESCRIPTION
Hi, I hacked this in quickly because it's a very common need of mine. Pull if it seems reasonable to you.

Basically this just adds `--stop-on-failure` (or `-f`) to make stop running tests as soon as there is a test failure or an error.
