### PR TITLE
Change Assertions#mu_pp to use #encode for changing the encoding

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -146,7 +146,7 @@ module MiniTest
 
     def mu_pp obj
       s = obj.inspect
-      s = s.force_encoding Encoding.default_external if defined? Encoding
+      s = s.encode Encoding.default_external if defined? Encoding
       s
     end
 

--- a/test/test_minitest_unit.rb
+++ b/test/test_minitest_unit.rb
@@ -6,6 +6,7 @@ MiniTest::Unit.autorun
 
 module MyModule; end
 class AnError < StandardError; include MyModule; end
+class ImmutableString < String; def inspect; super.freeze; end; end
 
 class TestMiniTestUnit < MiniTest::Unit::TestCase
   pwd = Pathname.new(File.expand_path(Dir.pwd))
@@ -1219,6 +1220,11 @@ FILE:LINE:in `test_assert_raises_triggered_subclass'
 
   def test_pass
     @tc.pass
+  end
+
+  def test_prints
+    printer = Class.new { extend MiniTest::Assertions }
+    @tc.assert_equal '"test"', printer.mu_pp(ImmutableString.new 'test')
   end
 
   def test_refute


### PR DESCRIPTION
In MacRuby, NSString#inspect returns self, which is not mutable and so it could cause
output to fail to print. NSString#encode was recently added, so there is now a middle
ground.
