### PR TITLE
Regressions caused by Mock blank slate change in 2.3.0

### DIFF
--- a/test/test_minitest_mock.rb
+++ b/test/test_minitest_mock.rb
@@ -122,6 +122,24 @@ class TestMiniTestMock < MiniTest::Unit::TestCase
     util_verify_bad
   end
 
+  def test_return_mock_does_not_raise
+    retval = MiniTest::Mock.new
+    mock = MiniTest::Mock.new
+    mock.expect(:foo, retval)
+    mock.foo
+
+    assert mock.verify
+  end
+
+  def test_mock_args_does_not_raise
+    arg = MiniTest::Mock.new
+    mock = MiniTest::Mock.new
+    mock.expect(:foo, nil, [arg])
+    mock.foo(arg)
+
+    assert mock.verify
+  end
+
   def util_verify_bad
     assert_raises MockExpectationError do
       @mock.verify


### PR DESCRIPTION
It looks like the blank slate change in the 2.3.0 release is causing tests that return a Mock or expect a Mock as an argument to fail.  I added some failing tests to demonstrate the regression, but I'm not sure what the fix should be.  What do you guys think?
