### PR TITLE
Mock.respond_to?(var) to work with strings

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -93,7 +93,7 @@ module MiniTest
     end
 
     def respond_to?(sym) # :nodoc:
-      return true if @expected_calls.has_key?(sym)
+      return true if @expected_calls.has_key?(sym.to_sym)
       return __respond_to?(sym)
     end
   end

--- a/test/test_minitest_mock.rb
+++ b/test/test_minitest_mock.rb
@@ -85,6 +85,7 @@ class TestMiniTestMock < MiniTest::Unit::TestCase
 
   def test_respond_appropriately
     assert @mock.respond_to?(:foo)
+    assert @mock.respond_to?('foo')
     assert !@mock.respond_to?(:bar)
   end
 


### PR DESCRIPTION
Fixed Mock.respond_to?(var) to convert var.to_sym so that even calls with string will work.

In ruby both Object.respond_to?(symbol) and Object.respond_to?(String) will work. MiniTest::Mock only handled the one with symbol.

I had existing code that uses method with string. Mocking results in false MockExpectationError:s without support for strings.

Example of code before this patch/fix.

``` ruby
"str".respond_to?(:squeeze) => true
"str".respond_to?('squeeze') => true

mock = MiniTest::Mock.new.expect(:squeeze, "squeezed")
mock.respond_to?(:squeeze) => true
mock.respond_to?('squeeze') => false

```
