### PR TITLE
Extend the ability of :let to accept a block with arguments

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -205,9 +205,9 @@ class MiniTest::Spec < MiniTest::Unit::TestCase
   end
 
   def self.let name, &block
-    define_method name do
+    define_method name do |*args|
       @_memoized ||= {}
-      @_memoized.fetch(name) { |k| @_memoized[k] = instance_eval(&block) }
+      @_memoized.fetch(name) { |k| @_memoized[k] = instance_exec(args, &block) }
     end
   end
 

--- a/test/test_minitest_spec.rb
+++ b/test/test_minitest_spec.rb
@@ -211,6 +211,10 @@ describe MiniTest::Spec, :let do
     $let_count
   end
 
+  let :full_name do |name|
+    "#{name.first} #{name.last}"
+  end
+
   it "is evaluated once per example" do
     _count.must_equal 0
 
@@ -227,6 +231,10 @@ describe MiniTest::Spec, :let do
     count.must_equal 2
 
     _count.must_equal 2
+  end
+
+  it "takes a block with arguments " do
+    full_name('John', 'Doe').must_equal "John Doe"
   end
 end
 


### PR DESCRIPTION
I wanted add the ability to do the following:

``` ruby
describe Person do
  let(:obj) { |changes| Obj.new(changes.first) }

  it 'should should be foo when foo' do
    obj('foo').must_equal 'foo'
  end

  it 'should be bar when bar' do
    obj('bar').must_equal 'bar'
  end
end
```

Instead of having to setup two different initializers or use an instance variable.
