### PR TITLE
Save original test description for minitest/spec

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -143,6 +143,15 @@ class MiniTest::Spec < MiniTest::Unit::TestCase
     @children ||= []
   end
 
+  ##
+  # Returns hash with test method names as keys, and original
+  # descriptions as values
+  #
+
+  def self.test_descriptions
+    @test_descriptions || {}
+  end
+
   def initialize name # :nodoc:
     super
     @@current_spec = self
@@ -196,6 +205,8 @@ class MiniTest::Spec < MiniTest::Unit::TestCase
     @specs += 1
 
     name = "test_%04d_%s" % [ @specs, desc.gsub(/\W+/, '_').downcase ]
+    @test_descriptions ||= {}
+    @test_descriptions[name] = desc
 
     define_method name, &block
 

--- a/test/test_minitest_spec.rb
+++ b/test/test_minitest_spec.rb
@@ -321,6 +321,9 @@ class TestMeta < MiniTest::Unit::TestCase
     assert_equal "inner thingy", y.desc
     assert_equal "very inner thingy", z.desc
 
+    assert_equal "top-level-it", x.test_descriptions["test_0001_top_level_it"]
+    assert_equal "inner-it", y.test_descriptions["test_0001_inner_it"]
+
     top_methods = %w(test_0001_top_level_it)
     inner_methods = %w(test_0001_inner_it)
 


### PR DESCRIPTION
Can be useful for tools like `turn` to display original test description and not infer it from test method name.
