### PR TITLE
Clarify the documentation of minitest/benchmark

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -128,9 +128,7 @@ benchmarks won't run.
     # Override self.bench_range or default range is [1, 10, 100, 1_000, 10_000]
     def bench_my_algorithm
       assert_performance_linear 0.9999 do |n| # n is a range value
-        n.times do
-          @obj.my_algorithm
-        end
+        @obj.my_algorithm(n)
       end
     end
   end

--- a/lib/minitest/benchmark.rb
+++ b/lib/minitest/benchmark.rb
@@ -77,8 +77,8 @@ class MiniTest::Unit
     #
     #   def bench_algorithm
     #     validation = proc { |x, y| ... }
-    #     assert_performance validation do |x|
-    #       @obj.algorithm
+    #     assert_performance validation do |n|
+    #       @obj.algorithm(n)
     #     end
     #   end
 
@@ -121,8 +121,8 @@ class MiniTest::Unit
     # Eg:
     #
     #   def bench_algorithm
-    #     assert_performance_constant 0.9999 do |x|
-    #       @obj.algorithm
+    #     assert_performance_constant 0.9999 do |n|
+    #       @obj.algorithm(n)
     #     end
     #   end
 
@@ -147,8 +147,8 @@ class MiniTest::Unit
     # Eg:
     #
     #   def bench_algorithm
-    #     assert_performance_exponential 0.9999 do |x|
-    #       @obj.algorithm
+    #     assert_performance_exponential 0.9999 do |n|
+    #       @obj.algorithm(n)
     #     end
     #   end
 
@@ -167,8 +167,8 @@ class MiniTest::Unit
     # Eg:
     #
     #   def bench_algorithm
-    #     assert_performance_linear 0.9999 do |x|
-    #       @obj.algorithm
+    #     assert_performance_linear 0.9999 do |n|
+    #       @obj.algorithm(n)
     #     end
     #   end
 
@@ -323,8 +323,8 @@ class MiniTest::Spec
   # Create a benchmark that verifies that the performance is linear.
   #
   #   describe "my class" do
-  #     bench_performance_linear "fast_algorithm", 0.9999 do
-  #       @obj.fast_algorithm
+  #     bench_performance_linear "fast_algorithm", 0.9999 do |n|
+  #       @obj.fast_algorithm(n)
   #     end
   #   end
 
@@ -338,8 +338,8 @@ class MiniTest::Spec
   # Create a benchmark that verifies that the performance is constant.
   #
   #   describe "my class" do
-  #     bench_performance_constant "zoom_algorithm!" do
-  #       @obj.zoom_algorithm!
+  #     bench_performance_constant "zoom_algorithm!" do |n|
+  #       @obj.zoom_algorithm!(n)
   #     end
   #   end
 
@@ -353,8 +353,8 @@ class MiniTest::Spec
   # Create a benchmark that verifies that the performance is exponential.
   #
   #   describe "my class" do
-  #     bench_performance_exponential "algorithm" do
-  #       @obj.algorithm
+  #     bench_performance_exponential "algorithm" do |n|
+  #       @obj.algorithm(n)
   #     end
   #   end
 


### PR DESCRIPTION
The documentation in the README about minitest/benchmark might be a bit misleading.
This tries to fix it and make it obvious you should use the parameter (n) with the algorithm you want to assert the performance.
(if you don't use the parameter, it will always take the same time, except if your algorithm depends on external factors or has side effects)

It might be even more obvious with something like:

```
assert_performance_linear 0.9999 do |n|
  fib(n)
end
```

But I kept the original examples as I think they are clear.
What do you think ?
