### PR TITLE
allow spec expectations directly in unit test methods

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -7,11 +7,11 @@ class Module # :nodoc:
     # warn "%-22p -> %p %p" % [meth, new_name, dont_flip]
     self.class_eval <<-EOM
       def #{new_name} *args, &block
-        return MiniTest::Spec.current.#{meth}(*args, &self) if
+        return MiniTest::Unit::TestCase.current.#{meth}(*args, &self) if
           Proc === self
-        return MiniTest::Spec.current.#{meth}(args.first, self) if
+        return MiniTest::Unit::TestCase.current.#{meth}(args.first, self) if
           args.size == 1 unless #{!!dont_flip}
-        return MiniTest::Spec.current.#{meth}(self, *args)
+        return MiniTest::Unit::TestCase.current.#{meth}(self, *args)
       end
     EOM
   end
@@ -132,20 +132,11 @@ class MiniTest::Spec < MiniTest::Unit::TestCase
     @@describe_stack
   end
 
-  def self.current # :nodoc:
-    @@current_spec
-  end
-
   ##
   # Returns the children of this spec.
 
   def self.children
     @children ||= []
-  end
-
-  def initialize name # :nodoc:
-    super
-    @@current_spec = self
   end
 
   def self.nuke_test_methods! # :nodoc:

--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -997,6 +997,11 @@ module MiniTest
         @__name__ = name
         @__io__ = nil
         @passed = nil
+        @@current = self
+      end
+
+      def self.current # :nodoc:
+        @@current
       end
 
       def io

--- a/test/test_minitest_spec_in_unit.rb
+++ b/test/test_minitest_spec_in_unit.rb
@@ -1,0 +1,15 @@
+require 'minitest/autorun'
+require 'minitest/spec'
+
+class TestSpecInUnit < MiniTest::Unit::TestCase
+  def test_using_spec_expectations_directly_in_unit_test_methods
+    1.must_equal 1
+    1.wont_equal 2
+  rescue NameError => error
+    if error.message =~ /^uninitialized class variable .+ in MiniTest::.+$/
+      flunk "spec expectations must be usable directly in unit test methods"
+    else
+      raise error
+    end
+  end
+end


### PR DESCRIPTION
This commit fixes the following error, which is raised when you try to use spec expectations directly inside a `MiniTest::Unit::TestCase` subclass' `def test_*` method.  See the included test case for example.  Cheers.

```
NameError: uninitialized class variable @@current_spec in MiniTest::Spec
```
