### PR TITLE
support RUBY_VERSION='2.0.0'

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -18,7 +18,7 @@ module MiniTest
 
   class Skip < Assertion; end
 
-  file = if RUBY_VERSION =~ /^1\.9/ then  # bt's expanded, but __FILE__ isn't :(
+  file = if RUBY_VERSION >= '1.9.0' then  # bt's expanded, but __FILE__ isn't :(
            File.expand_path __FILE__
          elsif  __FILE__ =~ /^[^\.]/ then # assume both relative
            require 'pathname'

--- a/test/test_minitest_unit.rb
+++ b/test/test_minitest_unit.rb
@@ -581,7 +581,7 @@ Finished tests in 0.00
   end
 
   def util_expand_bt bt
-    if RUBY_VERSION =~ /^1\.9/ then
+    if RUBY_VERSION >= '1.9.0' then
       bt.map { |f| (f =~ /^\./) ? File.expand_path(f) : f }
     else
       bt
@@ -991,7 +991,7 @@ FILE:LINE:in `test_assert_raises_triggered_different'
 ---------------"
 
     actual = e.message.gsub(/^.+:\d+/, 'FILE:LINE')
-    actual.gsub!(/block \(\d+ levels\) in /, '') if RUBY_VERSION =~ /^1\.9/
+    actual.gsub!(/block \(\d+ levels\) in /, '') if RUBY_VERSION >= '1.9.0'
 
     assert_equal expected, actual
   end
@@ -1012,7 +1012,7 @@ FILE:LINE:in `test_assert_raises_triggered_different_msg'
 ---------------"
 
     actual = e.message.gsub(/^.+:\d+/, 'FILE:LINE')
-    actual.gsub!(/block \(\d+ levels\) in /, '') if RUBY_VERSION =~ /^1\.9/
+    actual.gsub!(/block \(\d+ levels\) in /, '') if RUBY_VERSION >= '1.9.0'
 
     assert_equal expected, actual
   end
@@ -1056,7 +1056,7 @@ FILE:LINE:in `test_assert_raises_triggered_subclass'
 ---------------"
 
     actual = e.message.gsub(/^.+:\d+/, 'FILE:LINE')
-    actual.gsub!(/block \(\d+ levels\) in /, '') if RUBY_VERSION =~ /^1\.9/
+    actual.gsub!(/block \(\d+ levels\) in /, '') if RUBY_VERSION >= '1.9.0'
 
     assert_equal expected, actual
   end


### PR DESCRIPTION
Hi,

As you may know already, ruby trunk is now version 2.0!
After that, some tests for minitest in ruby trunk are broken.

I fixed some check of `RUBY_VERSION'. Please check it out.
