### PR TITLE
Remove unused block arguments to avoid creating Proc objects.

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -6,7 +6,7 @@ class Module # :nodoc:
   def infect_an_assertion meth, new_name, dont_flip = false # :nodoc:
     # warn "%-22p -> %p %p" % [meth, new_name, dont_flip]
     self.class_eval <<-EOM
-      def #{new_name} *args, &block
+      def #{new_name} *args
         return MiniTest::Spec.current.#{meth}(*args, &self) if
           Proc === self
         return MiniTest::Spec.current.#{meth}(args.first, self) if


### PR DESCRIPTION
I propose that unused block arguments should be removed.
It creates unnecessary Proc objects.

I applied similar patches to standard libraries in ruby-trunk(ruby/ruby@c3749b6a6d).

Thanks
