### PR TITLE
Additional tweaks and fixes for excludes support.

### DIFF
--- a/lib/minitest/excludes.rb
+++ b/lib/minitest/excludes.rb
@@ -67,7 +67,7 @@ class MiniTest::Unit::TestCase
     @__load_excludes__ ||=
       begin
         if name and not name.empty? then
-          file = File.join EXCLUDE_DIR, "#{name}.rb"
+          file = File.join EXCLUDE_DIR, "#{name.gsub(/:/, '@')}.rb"
           if File.exist? file
             instance_eval File.read(file), file, 1
             

--- a/test/test_minitest_excludes.rb
+++ b/test/test_minitest_excludes.rb
@@ -51,4 +51,56 @@ class TestMiniTestExcludes < MetaMetaMetaTestCase
   ensure
     MiniTest::Unit::TestCase::EXCLUDE_DIR.replace(old_exclude_base)
   end
+  
+  def test_nested_cls_excludes
+    srand 42
+    old_exclude_base = MiniTest::Unit::TestCase::EXCLUDE_DIR
+
+    @assertion_count = 0
+
+    Dir.mktmpdir do |path|
+      MiniTest::Unit::TestCase::EXCLUDE_DIR.replace(path)
+      File.open File.join(path, "Nested@@ATestCase.rb"), "w" do |f|
+        f.puts <<-EOM
+          exclude :test_test2, "because it is borked"
+        EOM
+      end
+
+      tc = Class.new(MiniTest::Unit::TestCase) do
+        def test_test1; assert true  end
+        def test_test2; assert false end # oh noes!
+        def test_test3; assert true  end
+      end
+
+      nest = Module.new
+      Object.const_set(:Nested, nest)
+      nest.const_set(:ATestCase, tc)
+
+      assert_equal %w(test_test1 test_test2 test_test3), Nested::ATestCase.test_methods
+
+      @tu.run %w[--seed 42 --verbose]
+
+      expected = <<-EOM.gsub(/^ {8}/, '')
+        Run options: --seed 42 --verbose
+
+        # Running tests:
+
+        Nested::ATestCase#test_test2 = 0.00 s = S
+        Nested::ATestCase#test_test1 = 0.00 s = .
+        Nested::ATestCase#test_test3 = 0.00 s = .
+
+
+        Finished tests in 0.00
+
+          1) Skipped:
+        test_test2(Nested::ATestCase) [FILE:LINE]:
+        because it is borked
+
+        3 tests, 2 assertions, 0 failures, 0 errors, 1 skips
+      EOM
+      assert_report expected
+    end
+  ensure
+    MiniTest::Unit::TestCase::EXCLUDE_DIR.replace(old_exclude_base)
+  end
 end


### PR DESCRIPTION
- Don't keep using the env var, since test may modify ENV
- Allow a nil reason
- Also skip setup and teardown for excluded tests

With these fixes, I've managed to set up excludes for MRI's test/ruby/test_*.rb so that they run to completion on JRuby.
