### PR TITLE
Fix output for flipped infections with a message

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -11,6 +11,8 @@ class Module # :nodoc:
           Proc === self
         return MiniTest::Spec.current.#{meth}(args.first, self) if
           args.size == 1 unless #{!!dont_flip}
+        return MiniTest::Spec.current.#{meth}(args.first, self, args.last) if
+          args.size == 2 unless #{!!dont_flip}
         return MiniTest::Spec.current.#{meth}(self, *args)
       end
     EOM

--- a/test/test_minitest_unit.rb
+++ b/test/test_minitest_unit.rb
@@ -1217,6 +1217,12 @@ FILE:LINE:in `test_assert_raises_triggered_subclass'
     end
   end
 
+  def test_expectation_with_a_message
+    util_assert_triggered "Expected: 2\n  Actual: 1" do
+      1.must_equal 2, ''
+    end
+  end
+
   def test_flunk
     util_assert_triggered 'Epic Fail!' do
       @tc.flunk


### PR DESCRIPTION
Hi, I noticed recently that `1.must_equal 2, 'some message'` returns the wrong output; it says that it expected 1, but the actual was 2, whereas it should be the other way around (note that the message-less `1.must_equal 2` works as, um, expected).

This commit tests this and _seems to fix it_, but please, please, please do check whether this is a valid fix; the code in `infect_an_assertion` fries my brain a bit every time I take a look at it, and I’m far from assuming I got this right.

Thanks again for minitest, I love it dearly!
