### PR TITLE
Fixed wont_be_empty

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -417,7 +417,7 @@ module MiniTest::Expectations
   #
   # :method: wont_be_empty
 
-  infect_an_assertion :refute_empty, :wont_be_empty
+  infect_an_assertion :refute_empty, :wont_be_empty, true
 
   ##
   # See MiniTest::Assertions#refute_equal

--- a/test/test_minitest_spec.rb
+++ b/test/test_minitest_spec.rb
@@ -312,6 +312,20 @@ describe MiniTest::Spec do
     end
   end
 
+  it "needs to verify non-emptyness" do
+    @assertion_count += 3
+
+    ['some item'].wont_be_empty.must_equal false
+
+    assert_triggered "Expected [] to not be empty." do
+      [].wont_be_empty
+    end
+
+    assert_triggered "msg.\nExpected [] to not be empty." do
+      [].wont_be_empty "msg"
+    end
+  end
+
   it "needs to verify non-identity" do
     1.wont_be_same_as(2).must_equal false
 


### PR DESCRIPTION
It broke on 2.9.1, was working on 2.9.0. Something as simple as ['hello'].wont_be_empty would give an error like:

wrong number of arguments (3 for 2)

For example: http://travis-ci.org/#!/xing/amiando/jobs/408896 fails, whereas http://travis-ci.org/#!/xing/amiando/jobs/409287 passes, when the only difference is the minitest version.
