### PR TITLE
Ensure expected args is an Array.  Otherwise, passing in a single arg le...

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -45,7 +45,7 @@ module MiniTest
     #   @mock.verify  # => raises MockExpectationError
 
     def expect(name, retval, args=[])
-      @expected_calls[name] = { :retval => retval, :args => args }
+      @expected_calls[name] = { :retval => retval, :args => Array(args) }
       self
     end
 


### PR DESCRIPTION
...ads to a weird error on verify.
