### PR TITLE
Make assert_in_epsilon work when both expected and actual are -ve numbers

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -233,7 +233,7 @@ module MiniTest
     # error less than +epsilon+.
 
     def assert_in_epsilon a, b, epsilon = 0.001, msg = nil
-      assert_in_delta a, b, ([a, b].min * epsilon).abs, msg
+      assert_in_delta a, b, ([a.abs, b.abs].min * epsilon), msg
     end
 
     ##

--- a/test/test_minitest_unit.rb
+++ b/test/test_minitest_unit.rb
@@ -869,6 +869,12 @@ class TestMiniTestUnitTestCase < MiniTest::Unit::TestCase
     end
   end
   
+  def test_assert_in_epsilon_triggered_negative_case
+    util_assert_triggered 'Expected |-1.1 - -1| (0.10000000000000009) to be < 0.1.' do
+      @tc.assert_in_epsilon -1.1, -1, 0.1
+    end
+  end
+  
   def test_assert_includes
     @assertion_count = 2
 


### PR DESCRIPTION
asset_in_epsilon -1, -1 fails, when I was expecting it to pass.

Commit contains test and patch.
