### PR TITLE
Added support for non-unicode symbols

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -193,8 +193,7 @@ class MiniTest::Spec < MiniTest::Unit::TestCase
     regexp = if RUBY_VERSION.to_f >= 1.9
       Regexp.new("[^[[:word:]]]+")
     else
-      $KCODE = 'U'
-      Regexp.new(/\W+/)
+      Regexp.new(/\W+/u)
     end
     name = "test_%04d_%s" % [ @specs, desc.gsub(regexp, '_').downcase ]
 

--- a/test/test_minitest_spec.rb
+++ b/test/test_minitest_spec.rb
@@ -689,8 +689,8 @@ class TestMeta < MiniTest::Unit::TestCase
       z = describe "second thingy" do end
     end
 
-    assert_equal ['test_0001_top_level_it', 'test_0002_не_латинские_буквы_и_спецсимволы_いった_α_β_γ_δ_ε_hello_world'],
-      x.instance_methods.grep(/^test/).map {|o| o.to_s}
+    assert_equal ['test_0001_top_level_it', 'test_0002_не_латинские_буквы_и_спецсимволы_いった_α_β_γ_δ_ε_hello_world'].sort,
+      x.instance_methods.grep(/^test/).map {|o| o.to_s}.sort
     assert_equal [], y.instance_methods.grep(/^test/)
     assert_equal [], z.instance_methods.grep(/^test/)
   end


### PR DESCRIPTION
``` ruby
it "тест не пройдет" do
  (1+1).must_equal 3
end
```

now will return readable Failure description:

``` text
  1) Failure:
test_0001_тест_не_пройдет(OkSpec) [test.rb:7]:
Expected 3, not 2.
```
