### PR TITLE
Pulls out logic for running a single suite method

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -821,7 +821,7 @@ module MiniTest
       filter = Regexp.new $1 if filter =~ /\/(.*)\//
 
       assertions = suite.send("#{type}_methods").grep(filter).map { |method|
-        _run_suite_method(suite, method).first
+        _run_suite_method(suite, method)._assertions
       }
 
       return assertions.size, assertions.inject(0) { |sum, n| sum + n }
@@ -844,7 +844,7 @@ module MiniTest
       print result
       puts if @verbose
 
-      [inst._assertions, time]
+      inst
     end
 
     def location e # :nodoc:
@@ -1025,6 +1025,9 @@ module MiniTest
 
       attr_reader :__name__ # :nodoc:
 
+      # the run time of the test.
+      attr_reader :run_time
+
       PASSTHROUGH_EXCEPTIONS = [NoMemoryError, SignalException,
                                 Interrupt, SystemExit] # :nodoc:
 
@@ -1039,8 +1042,7 @@ module MiniTest
             warn "\n%3d) %s" % [i + 1, msg]
           end
           warn ''
-          time = runner.start_time ? Time.now - runner.start_time : 0
-          warn "Current Test: %s#%s %.2fs" % [self.class, self.__name__, time]
+          warn "Current Test: %s#%s %.2fs" % [self.class, self.__name__, self.current_run_time(runner)]
           runner.status $stderr
         end if SUPPORTS_INFO_SIGNAL
 
@@ -1068,6 +1070,7 @@ module MiniTest
               result = runner.puke self.class, self.__name__, e
             end
           end
+          @run_time = current_run_time(runner)
           trap 'INFO', 'DEFAULT' if SUPPORTS_INFO_SIGNAL
         end
         result
@@ -1079,6 +1082,7 @@ module MiniTest
         @__name__ = name
         @__io__ = nil
         @passed = nil
+        @run_time = 0
         @@current = self
       end
 
@@ -1144,6 +1148,13 @@ module MiniTest
         else
           raise "Unknown test_order: #{self.test_order.inspect}"
         end
+      end
+
+      ##
+      # Returns the total time the test has been running so far.
+
+      def current_run_time runner
+        runner.start_time ? Time.now - runner.start_time : 0
       end
 
       ##


### PR DESCRIPTION
The goal is to make it easier for plugins/extensions to get access to
this data as this method has access to all the important information
like the suite, the method name, the time it took to run and how many
assertions were made.

let me know what you think. Example use case is [here](https://github.com/bhenderson/minitest-ci/blob/master/lib/minitest/ci.rb#L161)
