### PR TITLE
Avoided calls to Time.now and Time#- unless verbose is enabled

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -824,13 +824,18 @@ module MiniTest
         inst = suite.new method
         inst._assertions = 0
 
-        print "#{suite}##{method} = " if @verbose
+        if @verbose
+          print "#{suite}##{method} = "
+          start_time = Time.now
+        end
 
-        @start_time = Time.now
         result = inst.run self
-        time = Time.now - @start_time
 
-        print "%.2f s = " % time if @verbose
+        if @verbose
+          time = Time.now - start_time
+          print "%.2f s = " % time
+        end
+
         print result
         puts if @verbose
 


### PR DESCRIPTION
Looks like these calls to `Time.now` and `Time#-` are only necessary when `@verbose` is enabled.  I changed `@start_time` to be a local variable. I'm not sure if it needed to be an ivar, but I didn't see it being used elsewhere.
