### PR TITLE
Remove minitest-macruby-pride from the list of extensions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -268,7 +268,6 @@ minitest-instrument-db :: Store information about speed of test
                           execution provided by minitest-instrument in database
 minitest-libnotify     :: Test notifier for minitest via libnotify.
 minitest-macruby       :: Provides extensions to minitest for macruby UI testing.
-minitest-macruby-pride :: minitest/pride for macruby
 minitest-matchers      :: Adds support for RSpec-style matchers to minitest.
 minitest-mongoid       :: Mongoid assertion matchers for MiniTest
 minitest-must_not      :: Provides must_not as an alias for wont in MiniTest


### PR DESCRIPTION
Hey guys,

minitest-macruby-pride is not an extension, it was a fork that had patches to make minitest work properly with macruby.

Those patches have made their way upstream since then, nobody should be using macruby-minitest-pride anymore. I've just left it up for historical purposes.
