### PR TITLE
Fix warning in i_suck_and_my_tests_are_order_dependent!

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -1132,6 +1132,7 @@ module MiniTest
 
       def self.i_suck_and_my_tests_are_order_dependent!
         class << self
+          undef_method :test_order if method_defined? :test_order
           define_method :test_order do :alpha end
         end
       end

--- a/test/test_minitest_unit.rb
+++ b/test/test_minitest_unit.rb
@@ -1571,6 +1571,28 @@ FILE:LINE:in `test_assert_raises_triggered_subclass'
     assert_equal expected, sample_test_case.test_methods
   end
 
+  def test_i_suck_and_my_tests_are_order_dependent_bang_sets_test_order_alpha
+    @assertion_count = 0
+
+    shitty_test_case = Class.new MiniTest::Unit::TestCase
+
+    shitty_test_case.i_suck_and_my_tests_are_order_dependent!
+
+    assert_equal :alpha, shitty_test_case.test_order
+  end
+
+  def test_i_suck_and_my_tests_are_order_dependent_bang_does_not_warn
+    @assertion_count = 0
+
+    shitty_test_case = Class.new MiniTest::Unit::TestCase
+
+    def shitty_test_case.test_order ; :lol end
+
+    assert_silent do
+      shitty_test_case.i_suck_and_my_tests_are_order_dependent!
+    end
+  end
+
   def util_assert_triggered expected, klass = MiniTest::Assertion
     e = assert_raises(klass) do
       yield


### PR DESCRIPTION
Using `i_suck_and_my_tests_are_order_dependent!` emits a warning if `test_order` is already defined. I want my shitty test cases to be warning free!

Also since we're such good pals I added a test that `i_suck_and_my_tests_are_order_dependent!` does what it's supposed to.
