### PR TITLE
Add context method as an alias of describe

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -73,6 +73,7 @@ module Kernel # :nodoc:
     cls
   end
   private :describe
+  alias_method :context, :describe
 end
 
 ##

--- a/test/test_minitest_spec_context.rb
+++ b/test/test_minitest_spec_context.rb
@@ -1,0 +1,12 @@
+# encoding: utf-8
+require 'minitest/autorun'
+require 'stringio'
+
+describe MiniTest::Spec do
+  let(:object) { "41" }
+  context "supports nested context" do
+    it "the outside variable is available in the nested context" do
+      object.must_equal "41"
+    end
+  end
+end


### PR DESCRIPTION
The context method can be used within nested blocks in MiniTest::Spec
style. so a test may look like:

``` ruby

describe "#method" do
  context "when condition1" do
    it "does something"
      ...
    end
  end
  context "when condition2" do
    it "does something else"
      ...
    end
  end
end

```

I found this style is easier to follow in a test file
