### PR TITLE
Make assert_match behave consistently with test-unit version

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -275,8 +275,8 @@ module MiniTest
     def assert_match exp, act, msg = nil
       msg = message(msg) { "Expected #{mu_pp(exp)} to match #{mu_pp(act)}" }
       assert_respond_to act, :"=~"
-      exp = Regexp.new Regexp.escape exp if String === exp and String === act
-      assert exp =~ act, msg
+      exp = Regexp.new(Regexp.escape(exp)) if String === exp
+      assert act =~ exp, msg
     end
 
     ##

--- a/test/test_minitest_unit.rb
+++ b/test/test_minitest_unit.rb
@@ -927,13 +927,13 @@ class TestMiniTestUnitTestCase < MiniTest::Unit::TestCase
     @tc.assert_match(/\w+/, "blah blah blah")
   end
 
-  def test_assert_match_object
+  def test_assert_match_unusual_object
     @assertion_count = 2
 
-    pattern = Object.new
-    def pattern.=~(other) true end
+    unusual_object = Object.new
+    def unusual_object.=~(other) true end
 
-    @tc.assert_match pattern, 5
+    @tc.assert_match /pattern/, unusual_object
   end
 
   def test_assert_match_object_triggered


### PR DESCRIPTION
Currently, minitest's assert_match uses the #=~ method of the pattern, passing the object. This is inconsistent with test-unit (which does it the other way around), and also inconvenient when working with objects that have unusual implementations for #=~.

Notably, Mail::Body objects in mikel lindsaar's mail gem (https://github.com/mikel/mail/blob/master/lib/mail/body.rb, line 84) have an interesting #=~; the Mail::Body decodes itself before attempting to match. This has the convenient side effect of enabling the user to run assert_match against email bodies directly, without decoding them first.

The current implementation is limited to relying on Regexp#=~, so tricks like the one mikel pulled to make the user's life easier aren't possible. I also think there's value in not changing the behavior from test-unit's, for users upgrading from 1.8 to 1.9 and switching from test-unit to minitest.
