### PR TITLE
Mocker module for extending any object

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -7,16 +7,37 @@ end # omg... worst bug ever. rdoc doesn't allow 1-liners
 module MiniTest
 
   ##
-  # All mock objects are an instance of Mock
+  # A Mocker module to extend any object. Afterwards, acts just like a Mock
+  # object except that only expected methods are temporarily removed. All
+  # expected methods are reset when verify is called.
+  #
+  #   @mock = Object.new
+  #   def @mock.foo() 'hi' end
+  #   @mock.extend MiniTest::Mocker
+  #   @mock.expect :foo, 'hello world'
+  #   @mock.foo # => 'hello world'
+  #
+  #   @mock.verify # => true
+  #   @mock.foo # => 'hi'
 
   module Mocker
 
-    def self.extended base
+    def self.alias_method_for o, orig, reverse = false # :nodoc:
+      name = "__mocker_#{orig}"
+      name, orig = orig, name if reverse
+      mc = class << o; self; end
+      if mc.method_defined?(orig)
+        mc.__send__ :alias_method, name, orig
+        mc.__send__ :undef_method, orig
+      end
+    end
+
+    def self.extended base # :nodoc:
       base.instance_variable_set :@expected_calls, Hash.new { |calls, name| calls[name] = [] }
       base.instance_variable_set :@actual_calls  , Hash.new { |calls, name| calls[name] = [] }
     end
 
-    def self.included base
+    def self.included base # :nodoc:
       mod = self
       base.class_eval do
         skip_methods = %w(object_id respond_to_missing? inspect === to_s)
@@ -56,6 +77,7 @@ module MiniTest
 
     def expect(name, retval, args=[])
       raise ArgumentError, "args must be an array" unless Array === args
+      MiniTest::Mocker.alias_method_for self, name
       @expected_calls[name] << { :retval => retval, :args => args }
       self
     end
@@ -80,6 +102,11 @@ module MiniTest
         end
       end
       true
+    ensure
+      @expected_calls.each_key do |name|
+        # restore method if exists
+        MiniTest::Mocker.alias_method_for self, name, true
+      end
     end
 
     def method_missing(sym, *args) # :nodoc:
@@ -120,6 +147,9 @@ module MiniTest
       return super
     end
   end
+
+  ##
+  # All mock objects are an instance of Mock
 
   class Mock
     include Mocker

--- a/test/test_minitest_mock.rb
+++ b/test/test_minitest_mock.rb
@@ -4,6 +4,13 @@ require 'minitest/unit'
 MiniTest::Unit.autorun
 
 class TestMiniTestMock < MiniTest::Unit::TestCase
+
+  class MockerClass
+    def self.bar() 4 end
+    def initialize() @foo = 3 end
+    def foo() @foo end
+  end
+
   def setup
     @mock = MiniTest::Mock.new.expect(:foo, nil)
     @mock.expect(:meaning_of_life, 42)
@@ -185,6 +192,87 @@ class TestMiniTestMock < MiniTest::Unit::TestCase
     mock.foo :baz
 
     assert_raises(MockExpectationError) { mock.verify }
+  end
+
+  def test_extend_with_mocker
+    @mock = Object.new
+    def @mock.foo() 3 end
+    def @mock.bar() 4 end
+
+    @mock.extend MiniTest::Mocker
+
+    @mock.expect :foo, 42
+    assert_equal 42, @mock.foo
+    assert_equal 4, @mock.bar
+
+    assert @mock.verify
+
+    # methods restored
+    assert_equal 3, @mock.foo
+    assert_equal 4, @mock.bar
+  end
+
+  def test_extend_raises
+    @mock = Object.new
+    def @mock.foo(a=nil) 3 end
+    @mock.extend MiniTest::Mocker
+
+    @mock.expect :foo, 42, [:bar]
+
+    assert_raises(ArgumentError) { @mock.foo }
+    util_verify_bad
+
+    assert_equal 3, @mock.foo, 'expected method to be restored'
+  end
+
+  def test_extend_only_instance
+    @mock = Object.new
+    @mock.extend MiniTest::Mocker
+
+    @mock.expect :foo, 42
+    assert_equal 42, @mock.foo
+    refute @mock.class.new.respond_to?(:foo)
+  end
+
+  def test_extend_does_not_remove_methods
+    @mock = Object.new
+    assert @mock.to_s
+  end
+
+  def test_extend_non_existent_methods
+    @mock = Object.new
+    @mock.extend MiniTest::Mocker
+
+    @mock.expect :foo, 42
+    assert_equal 42, @mock.foo
+    assert @mock.verify
+  end
+
+  def test_extend_verify_replaces_all_methods
+    @mock = Object.new
+    def @mock.foo() 3 end
+    def @mock.bar() 4 end
+    @mock.extend MiniTest::Mocker
+
+    @mock.expect :foo, 42
+    @mock.expect :bar, 42
+
+    util_verify_bad
+
+    assert_equal 3, @mock.foo
+    assert_equal 4, @mock.bar
+  end
+
+  def test_extend_a_class
+    @mock = MockerClass
+    @mock.extend MiniTest::Mocker
+    assert_equal 3, @mock.new.foo
+    @mock.expect :bar, 42
+    assert_equal 42, @mock.bar
+
+    @mock.verify
+
+    assert_equal 4, @mock.bar
   end
 
   def util_verify_bad


### PR DESCRIPTION
I wrote a patch for minitest/mock which allows any object to be extended with expect/verify methods.

``` ruby
@mock = Object.new
def @mock.foo() 'hi' end
@mock.extend MiniTest::Mocker
@mock.expect :foo, 'hello world'
@mock.foo # => 'hello world'

@mock.verify # => true
@mock.foo # => 'hi'
```

Is this interesting to you at all? Method restoration is done via method aliasing.
