### PR TITLE
assert_match broke backword comatibillity.

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -274,8 +274,8 @@ module MiniTest
 
     def assert_match matcher, obj, msg = nil
       msg = message(msg) { "Expected #{mu_pp matcher} to match #{mu_pp obj}" }
-      assert_respond_to matcher, :"=~"
-      matcher = Regexp.new Regexp.escape matcher if String === matcher
+      assert_respond_to obj, :"=~"
+      matcher = Regexp.new Regexp.escape matcher if String === matcher and String === obj
       assert matcher =~ obj, msg
     end
 
@@ -575,8 +575,8 @@ module MiniTest
 
     def refute_match matcher, obj, msg = nil
       msg = message(msg) {"Expected #{mu_pp matcher} to not match #{mu_pp obj}"}
-      assert_respond_to matcher, :"=~"
-      matcher = Regexp.new Regexp.escape matcher if String === matcher
+      assert_respond_to obj, :"=~"
+      matcher = Regexp.new Regexp.escape matcher if String === matcher and String === obj
       refute matcher =~ obj, msg
     end
 


### PR DESCRIPTION
see aloso:
https://bugs.ruby-lang.org/issues/6405
