### PR TITLE
Support drive letter on Windows.  yes, the original code is metameta.(same as #125)

### DIFF
--- a/test/metametameta.rb
+++ b/test/metametameta.rb
@@ -19,8 +19,13 @@ class MetaMetaMetaTestCase < MiniTest::Unit::TestCase
     output = @output.string.dup
     output.sub!(/Finished tests in .*/, "Finished tests in 0.00")
     output.sub!(/Loaded suite .*/, 'Loaded suite blah')
-    output.gsub!(/\[[^\]:]+:\d+\]/, '[FILE:LINE]')
-    output.gsub!(/^(\s+)[^:]+:\d+:in/, '\1FILE:LINE:in')
+    if /mswin|mingw/ =~ RUBY_PLATFORM
+      output.gsub!(/\[(?:[A-Za-z]:)?[^\]:]+:\d+\]/, '[FILE:LINE]')
+      output.gsub!(/^(\s+)(?:[A-Za-z]:)?[^:]+:\d+:in/, '\1FILE:LINE:in')
+    else
+      output.gsub!(/\[[^\]:]+:\d+\]/, '[FILE:LINE]')
+      output.gsub!(/^(\s+)[^:]+:\d+:in/, '\1FILE:LINE:in')
+    end
     assert_equal(expected, output)
   end
 


### PR DESCRIPTION
Patch provided from MRI by Usaku NAKAMURA.
## See also:
- https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/35587
