### PR TITLE
Prevent running methods which starts with tests instead of test_

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -1139,7 +1139,7 @@ module MiniTest
       end
 
       def self.test_methods # :nodoc:
-        methods = public_instance_methods(true).grep(/^test/).map { |m| m.to_s }
+        methods = public_instance_methods(true).grep(/^test_/).map { |m| m.to_s }
 
         case self.test_order
         when :random then


### PR DESCRIPTION
Hi,

I would like to push this change that prevent running methods which starts with tests instead of test_. I saw the Regexp is already used in the tests to kill all the test methods.

For exemple in one of my Rails app, there is two methods named tests_path and tests_url in my TestCase superclass (are they provided by RoR or another gem is another question). The results is that in every test case, they are both run as test (0.3s penalty per test).

Moreover, this will behave like in test/unit and will make any migration easier.

Thanks for the good framework and have a nice week,
Olivier
