### PR TITLE
Assertion failing in teardown-related code should mark test as failed.

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -1070,6 +1070,7 @@ module MiniTest
             rescue *PASSTHROUGH_EXCEPTIONS
               raise
             rescue Exception => e
+              @passed = false
               result = runner.puke self.class, self.__name__, e
             end
           end

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -490,6 +490,34 @@ Finished tests in 0.00
     assert_equal expected, call_order
   end
 
+  def test_teardown_with_successful_assertion
+    test_class = Class.new(MiniTest::Unit::TestCase) do
+      define_method :teardown do
+        assert true
+      end
+
+      def test_omg; assert true; end
+    end
+
+    test = test_class.new(:test_omg)
+    test.run(@tu)
+    assert test.passed?
+  end
+
+  def test_teardown_with_failing_assertion
+    test_class = Class.new(MiniTest::Unit::TestCase) do
+      define_method :teardown do
+        flunk
+      end
+
+      def test_omg; assert true; end
+    end
+
+    test = test_class.new(:test_omg)
+    test.run(@tu)
+    refute test.passed?
+  end
+
   def test_after_teardown
     call_order = []
     Class.new(MiniTest::Unit::TestCase) do


### PR DESCRIPTION
Assertions that occur within teardown-related code do not mark the test
as failed i.e. although `Unit#failures` is incremented and the `result`
is set to "E", `TestCase#passed?` returns `true`.

Neither `TestCase#passed?` nor its associated instance variable
`@passed` appear to be used internally, so this isn't currently causing
any problems within `MiniTest` itself. However, the `#passed?` method is
exposed as part of the API and its inconsistent behaviour has caused me
some confusion.
