### PR TITLE
Teardown hooks should be called in reverse order (regression).

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -1292,7 +1292,7 @@ module MiniTest
       end
 
       def run_teardown_hooks # :nodoc:
-        _run_hooks self.class.teardown_hooks
+        _run_hooks self.class.teardown_hooks.reverse
       end
 
       include MiniTest::Assertions


### PR DESCRIPTION
This fixes a regression introduced in
ef5507bbc35de4ade48ad1a0f350c21d9d1ecd6e - I was seeing a number of test
failures without this fix.
