### PR TITLE
Setup and teardown hooks should be run even in a TestCase.

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -240,14 +240,6 @@ class MiniTest::Spec < MiniTest::Unit::TestCase
   end
 
   # :stopdoc:
-  def after_setup
-    run_setup_hooks
-  end
-
-  def before_teardown
-    run_teardown_hooks
-  end
-
   class << self
     attr_reader :desc
     alias :specify :it

--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -1055,6 +1055,7 @@ module MiniTest
           self.before_setup
           self.setup
           self.after_setup
+          self.run_setup_hooks
           self.run_test self.__name__
           result = "." unless io?
           @passed = true
@@ -1064,7 +1065,7 @@ module MiniTest
           @passed = false
           result = runner.puke self.class, self.__name__, e
         ensure
-          %w{ before_teardown teardown after_teardown }.each do |hook|
+          %w{ before_teardown run_teardown_hooks teardown after_teardown }.each do |hook|
             begin
               self.send hook
             rescue *PASSTHROUGH_EXCEPTIONS

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -515,7 +515,7 @@ class TestMiniTestUnit < MetaMetaMetaTestCase
   def test_setup_hooks
     call_order = []
 
-    tc = Class.new MiniTest::Spec do
+    tc = Class.new MiniTest::Unit::TestCase do
       define_method :setup do
         super()
         call_order << :method
@@ -552,7 +552,7 @@ class TestMiniTestUnit < MetaMetaMetaTestCase
   def test_teardown_hooks
     call_order = []
 
-    tc = Class.new MiniTest::Spec do
+    tc = Class.new MiniTest::Unit::TestCase do
       define_method :teardown do
         super()
         call_order << :method


### PR DESCRIPTION
Since `TestCase.add_setup_hook` and `TestCase.add_teardown_hook` are
defined on `TestCase` it seems logical that they should run when you run
a `TestCase`, not just when you run a `Spec`.

I considered simply moving the definitions of `Spec#run_setup_hooks`
and `Spec#run_teardown_hooks` from `Spec` up into `TestCase`, but this
would mean that anyone defining their own `#setup` or `#teardown`
method would have to remember to call `#super`, which I suspect is not
common practice. This way the hooks are guaranteed to fire.

Another possible solution would be to move `TestCase.add_setup_hook` and
`TestCase.add_teardown_hook` down into `Spec`, but I think this
mechanism is likely to be just as useful to `TestCase` diehards, so it
would be a shame to deny them.
