### PR TITLE
Add an `after_test` lifecycle hook for library developers.

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -1054,6 +1054,11 @@ module MiniTest
       #       super
       #     end
       #
+      #     def after_test
+      #       # ... stuff to do after the test is run
+      #       super
+      #     end
+      #
       #     def before_teardown
       #       super
       #       # ... stuff to do before teardown is run
@@ -1070,6 +1075,14 @@ module MiniTest
       #   end
 
       def before_setup; end
+
+      ##
+      # Runs after every test, but is considered part of the test.
+      # This hook is meant for libraries to extend minitest.
+      # It is not meant to be used by test developers.
+      #
+      # See #before_setup for an example.
+      def after_test; end
 
       ##
       # Runs after every test, before teardown. This hook is meant for
@@ -1198,6 +1211,7 @@ module MiniTest
           self.setup
           self.after_setup
           self.run_test self.__name__
+          self.after_test
           result = "." unless io?
           @passed = true
         rescue *PASSTHROUGH_EXCEPTIONS

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -461,6 +461,47 @@ class TestMiniTestUnit < MetaMetaMetaTestCase
     refute test.passed?
   end
 
+  def test_after_test
+    call_order = []
+    Class.new MiniTest::Unit::TestCase do
+      define_method :test_omg do
+        call_order << :test_omg
+      end
+
+      define_method :after_test do
+        call_order << :after_test
+      end
+
+      define_method :before_teardown do
+        call_order << :before_teardown
+      end
+    end
+
+    @tu.run %w[--seed 42]
+
+    expected = [:test_omg, :after_test, :before_teardown]
+    assert_equal expected, call_order
+  end
+
+  def test_after_test_not_called_when_test_flunks
+    call_order = []
+    Class.new MiniTest::Unit::TestCase do
+      define_method :test_omg do
+        call_order << :test_omg
+        flunk
+      end
+
+      define_method :after_test do
+        call_order << :after_test
+      end
+    end
+
+    @tu.run %w[--seed 42]
+
+    expected = [:test_omg]
+    assert_equal expected, call_order
+  end
+
   def test_after_teardown
     call_order = []
     Class.new MiniTest::Unit::TestCase do


### PR DESCRIPTION
- I'd like to be able to add assertions to the end of each test
  via a MiniTest plugin.
- While I could do this one of the teardown hooks, this means that
  since the teardown hooks are in an `ensure` block, my extra assertions
  will _always_ run even if an assertion fails within the test itself.
  This then means it's possible to see multiple assertion failures in a
  single test, which seems confusing.
- The `after_test` hook that I'm suggesting here is run immediately
  after the test itself and is within the same `begin`/`rescue` block.

This patch solves the problem [I mentioned](https://github.com/seattlerb/minitest/pull/147#issuecomment-7136234) the other day in one of the other pull requests.

This hook would be really useful for integrating [Mocha](https://github.com/freerange/mocha) into MiniTest properly without having to do any monkey-patching.

I'm not sure `after_test` is the best name, because it doesn't convey that the hook is called _as part of_ the test. Perhaps `test_epilogue` or something would be better?

Thanks for all your help so far. It's much appreciated.
