### PR TITLE
Object#stub can now be used without a block (along with Object#unstub) - Closes #152

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -157,10 +157,23 @@ class Object # :nodoc:
       end
     end
 
-    yield self
-  ensure
-    metaclass.send :undef_method, name
-    metaclass.send :alias_method, name, new_name
-    metaclass.send :undef_method, new_name
+    if block_given?
+      begin
+        yield self
+      ensure
+        unstub name
+      end
+    end
+  end
+
+  def unstub name
+    original_name = "__minitest_stub__#{name}"
+    metaclass = class << self; self; end
+
+    if metaclass.method_defined? original_name
+      metaclass.send :undef_method, name
+      metaclass.send :alias_method, name, original_name
+      metaclass.send :undef_method, original_name
+    end
   end
 end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -221,15 +221,26 @@ class TestMiniTestStub < MiniTest::Unit::TestCase
   end
 
   def assert_stub val_or_callable
-    @assertion_count += 1
+    @assertion_count += 2
 
     t = Time.now.to_i
 
+    assert_stub_block val_or_callable
+    assert_stub_non_block val_or_callable
+
+    @tc.assert_operator Time.now.to_i, :>=, t
+  end
+
+  def assert_stub_block val_or_callable
     Time.stub :now, val_or_callable do
       @tc.assert_equal 42, Time.now
     end
+  end
 
-    @tc.assert_operator Time.now.to_i, :>=, t
+  def assert_stub_non_block val_or_callable
+    Time.stub :now, val_or_callable
+    @tc.assert_equal 42, Time.now
+    Time.unstub :now
   end
 
   def test_stub_value
@@ -270,5 +281,11 @@ class TestMiniTestStub < MiniTest::Unit::TestCase
     end
 
     @tc.assert_equal "bar", val
+  end
+
+  def test_unstub_is_not_destructive
+    t = Time.now.to_i
+    Time.unstub :now
+    @tc.assert_operator Time.now.to_i, :>=, t
   end
 end


### PR DESCRIPTION
@zenspider WDYT?
