### PR TITLE
add a backtrace filter object

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -30,24 +30,36 @@ module MiniTest
 
   class Skip < Assertion; end
 
-  def self.filter_backtrace bt # :nodoc:
-    return ["No backtrace"] unless bt
+  class << self
+    attr_accessor :backtrace_filter
+  end
 
-    new_bt = []
+  class Filter # :nodoc:
+    def filter bt
+      return ["No backtrace"] unless bt
 
-    unless $DEBUG then
-      bt.each do |line|
-        break if line =~ /lib\/minitest/
-        new_bt << line
+      new_bt = []
+
+      unless $DEBUG then
+        bt.each do |line|
+          break if line =~ /lib\/minitest/
+          new_bt << line
+        end
+
+        new_bt = bt.reject { |line| line =~ /lib\/minitest/ } if new_bt.empty?
+        new_bt = bt.dup if new_bt.empty?
+      else
+        new_bt = bt.dup
       end
 
-      new_bt = bt.reject { |line| line =~ /lib\/minitest/ } if new_bt.empty?
-      new_bt = bt.dup if new_bt.empty?
-    else
-      new_bt = bt.dup
+      new_bt
     end
+  end
 
-    new_bt
+  self.backtrace_filter = Filter.new
+
+  def self.filter_backtrace bt # :nodoc:
+    backtrace_filter.filter bt
   end
 
   ##


### PR DESCRIPTION
Rails has it's own backtrace filter, but the code to install the filter [is crazy](https://github.com/rails/rails/pull/2540/files).  I think this is due to the backtrace being filtered via a class method on the `MiniTest` constant.

I've pulled the filter in to an object that you can set, which would allow Rails to insert it's own backtrace filter object.  I'm not _super_ keen on this code, but I really want to avoid the monkey patches on the Rails end.  Pushing the backtrace filter to an instance method didn't seem feasible.  I'm open to any suggestions!
