### PR TITLE
Add include_private param to MiniTest::Mock#respond_to?

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -120,9 +120,9 @@ module MiniTest
       retval
     end
 
-    def respond_to?(sym) # :nodoc:
+    def respond_to?(sym, include_private = false) # :nodoc:
       return true if @expected_calls.has_key?(sym.to_sym)
-      return __respond_to?(sym)
+      return __respond_to?(sym, include_private)
     end
   end
 end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -96,6 +96,7 @@ class TestMiniTestMock < MiniTest::Unit::TestCase
 
   def test_respond_appropriately
     assert @mock.respond_to?(:foo)
+    assert @mock.respond_to?(:foo, true)
     assert @mock.respond_to?('foo')
     assert !@mock.respond_to?(:bar)
   end


### PR DESCRIPTION
`Object#respond_to?` takes two parameters, so `MiniTest::Mock#respond_to?` should too.
