### PR TITLE
Add assert_no_match

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -293,6 +293,16 @@ module MiniTest
     end
 
     ##
+    # Fails unless +matcher+ <tt>!~</tt> +obj+
+
+    def assert_no_match nexp, act, msg = nil
+      msg = message(msg) { "Expected #{mu_pp(nexp)} to NOT match #{mu_pp(act)}" }
+      assert_respond_to act, :"=~"
+      nexp = Regexp.new Regexp.escape nexp if String === nexp and String === act
+      assert nexp !~ act, msg
+    end
+
+    ##
     # Fails unless +obj+ is nil
 
     def assert_nil obj, msg = nil

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -871,6 +871,39 @@ class TestMiniTestUnitTestCase < MiniTest::Unit::TestCase
     end
   end
 
+  def test_assert_no_match
+    @assertion_count = 2
+    @tc.assert_no_match(/xx/, "blah blah blah")
+  end
+
+  def test_assert_no_match_matcher_object
+    @assertion_count = 2
+
+    pattern = Object.new
+    def pattern.=~(other) false end
+
+    @tc.assert_no_match pattern, 5
+  end
+
+  def test_assert_no_match_object_triggered
+    @assertion_count = 2
+
+    pattern = Object.new
+    def pattern.=~(other) true end
+    def pattern.inspect; "[Object]" end
+
+    util_assert_triggered 'Expected [Object] to NOT match 5.' do
+      @tc.assert_no_match pattern, 5
+    end
+  end
+
+  def test_assert_no_match_triggered
+    @assertion_count = 2
+    util_assert_triggered 'Expected /\d+/ to match "blah blah blah".' do
+      @tc.assert_match(/\d+/, "blah blah blah")
+    end
+  end
+
   def test_assert_nil
     @tc.assert_nil nil
   end


### PR DESCRIPTION
Yes, you can do this:

```
 assert_match /^((?!error).)+$/i, msg
```

But this is nicer:

```
assert_no_match /error/i, msg
```
