### PR TITLE
autorun: run tests when exit() called explicitly

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -764,7 +764,8 @@ module MiniTest
 
     def self.autorun
       at_exit {
-        next if $! # don't run if there was an exception
+        # don't run if there was an exception
+        next if $! and not $!.kind_of? SystemExit
 
         # the order here is important. The at_exit handler must be
         # installed before anyone else gets a chance to install their

--- a/test/minitest/test_minitest_autorun.rb
+++ b/test/minitest/test_minitest_autorun.rb
@@ -1,0 +1,20 @@
+require 'minitest/autorun'
+
+describe 'at_exit', 'when dealing with exceptions' do
+  ruby = 'ruby -I lib -r minitest/autorun'
+
+  it 'runs tests if no exception was raised' do
+    `#{ruby} -e nil`.wont_be_empty
+  end
+
+  it 'runs tests if SystemExit was raised' do
+    `#{ruby} -e exit`.wont_be_empty
+    `#{ruby} -e 'at_exit { exit }'`.wont_be_empty
+    `#{ruby} -e 'at_exit { raise SystemExit }'`.wont_be_empty
+  end
+
+  it 'does not run tests if an exception other than SystemExit was raised' do
+    `#{ruby} -e 'at_exit { raise }' 2>/dev/null`.must_be_empty
+    `#{ruby} -e 'at_exit { raise Exception }' 2>/dev/null`.must_be_empty
+  end
+end


### PR DESCRIPTION
This change allows minitest/autorun to run tests even if somebody calls
exit() explicitly or loads in another testing library that calls exit()
from its very own autorun at_exit handler.  In particular, see this
related issue in RSpec https://github.com/rspec/rspec-core/pull/720.
