### PR TITLE
Describe minitest-around extension in README.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -276,6 +276,7 @@ fixture loading:
 == Known Extensions:
 
 capybara_minitest_spec  :: Bridge between Capybara RSpec matchers and MiniTest::Spec expectations (e.g. page.must_have_content('Title')).
+minitest-around         :: Around block for minitest. An alternative to setup/teardown dance.
 minitest-capistrano     :: Assertions and expectations for testing Capistrano recipes
 minitest-capybara       :: Capybara matchers support for minitest unit and spec
 minitest-chef-handler   :: Run Minitest suites as Chef report handlers
@@ -328,7 +329,6 @@ Authors... Please send me a pull request with a description of your minitest ext
 * guard-minitest-decisiv
 * minitest-activemodel
 * minitest-ar-assertions
-* minitest-around
 * minitest-capybara-unit
 * minitest-colorer
 * minitest-deluxe


### PR DESCRIPTION
Moved from "Unknown Extensions" to "Known Extensions".
