### PR TITLE
benchmarks: add fit_logarithic method

### DIFF
--- a/lib/minitest/benchmark.rb
+++ b/lib/minitest/benchmark.rb
@@ -156,6 +156,26 @@ class MiniTest::Unit # :nodoc:
 
     ##
     # Runs the given +work+ and asserts that the times gathered fit to
+    # match a logarithmic curve within a given error +threshold+.
+    #
+    # Fit is calculated by #fit_logarithmic.
+    #
+    # Ranges are specified by ::bench_range.
+    #
+    # Eg:
+    #
+    #   def bench_algorithm
+    #     assert_performance_logarithmic 0.9999 do |n|
+    #       @obj.algorithm(n)
+    #     end
+    #   end
+
+    def assert_performance_logarithmic threshold = 0.99, &work
+      assert_performance validation_for_fit(:logarithmic, threshold), &work
+    end
+
+    ##
+    # Runs the given +work+ and asserts that the times gathered fit to
     # match a straight line within a given error +threshold+.
     #
     # Fit is calculated by #fit_linear.
@@ -228,6 +248,29 @@ class MiniTest::Unit # :nodoc:
 
       return Math.exp(a), b, fit_error(xys) { |x| Math.exp(a + b * x) }
     end
+
+    ##
+    # To fit a functional form: y = a + b*ln(x).
+    #
+    # Takes x and y values and returns [a, b, r^2].
+    #
+    # See: http://mathworld.wolfram.com/LeastSquaresFittingLogarithmic.html
+
+    def fit_logarithmic xs, ys
+      n     = xs.size
+      xys   = xs.zip(ys)
+      slnx2 = sigma(xys) { |x,y| Math.log(x) ** 2 }
+      slnx  = sigma(xys) { |x,y| Math.log(x)      }
+      sylnx = sigma(xys) { |x,y| y * Math.log(x)  }
+      sy    = sigma(xys) { |x,y| y                }
+
+      c = n * slnx2 - slnx ** 2
+      b = ( n * sylnx - sy * slnx ) / c
+      a = (sy - b * slnx) / n
+
+      return a, b, fit_error(xys) { |x| a + b * Math.log(x) }
+    end
+
 
     ##
     # Fits the functional form: a + bx.

--- a/test/minitest/test_minitest_benchmark.rb
+++ b/test/minitest/test_minitest_benchmark.rb
@@ -44,6 +44,22 @@ class TestMiniTestBenchmark < MiniTest::Unit::TestCase
     assert_fit :exponential, x, y, 0.95, 13.81148, -0.1820
   end
 
+  def test_fit_logarithmic_clean
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    y = x.map { |n| 1.1 + 2.1 * Math.log(n) }
+
+    assert_fit :logarithmic, x, y, 1.0, 1.1, 2.1
+  end
+
+  def test_fit_logarithmic_noisy
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    # Generated with
+    # y = x.map { |n| jitter = 0.999 + 0.002 * rand; (Math.log(n) ) * jitter }
+    y = [0.0, 0.6935, 1.0995, 1.3873, 1.6097]
+
+    assert_fit :logarithmic, x, y, 0.95, 0, 1
+  end
+
   def test_fit_constant_clean
     x = (1..5).to_a
     y = [5.0, 5.0, 5.0, 5.0, 5.0]


### PR DESCRIPTION
Adds #fit_logarithmic & #assert_performance_logarithmic methods

Useful for testing binary search algorithms, for example.

I closely followed the fit_exponential code as a guide.
