### PR TITLE
Unit: Errors in teardown are not recorded

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -1313,7 +1313,7 @@ module MiniTest
               raise
             rescue Exception => e
               @passed = false
-              captured_exception = e
+              captured_exception ||= e
               result = runner.puke self.class, self.__name__, e
             end
           end

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -1820,6 +1820,22 @@ class TestMiniTestUnitRecording < MetaMetaMetaTestCase
     end
   end
 
+  def test_record_error_in_test_trumps_error_in_teardown
+    Class.new MiniTest::Unit::TestCase do
+      def test_error
+        raise AnError
+      end
+
+      def teardown
+        raise "unhandled exception"
+      end
+    end
+
+    with_recording do |recording|
+      assert_instance_of AnError, recording["test_error"]
+    end
+  end
+
   def test_record_skip
     Class.new MiniTest::Unit::TestCase do
       def test_skip


### PR DESCRIPTION
When an error or assertion failure occurs in a `teardown` method, it is not recorded correctly.  That is, `record` has been sent with the passing test information before `teardown` is sent, and no further information is recorded after that.   This doesn't affect the standard runner, because it relies on `puke` to do its job.  But it affects other runners that rely on `record` instead, such as [minitest-reporters](https://github.com/CapnKernul/minitest-reporters).

This pull request consists of three commits:
1. Add test coverage around the current incorrect behavior of `record`.  There may be a better way to write these tests.
2. Modify the relevant test to have the desired new behavior.
3. (Optional) If an error/assertion failure is raised in both the test body and `teardown`, record the one from the test body.

See also the [related issue](https://github.com/CapnKernul/minitest-reporters/issues/49) I filed for minitest-reporters.
