### PR TITLE
Add error handling when shelling out for diff

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -154,6 +154,8 @@ module MiniTest
       end
 
       result
+    rescue
+      "Expected: #{mu_pp exp}\n  Actual: #{mu_pp act}"
     end
 
     ##

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -797,6 +797,14 @@ class TestMiniTestUnitTestCase < MiniTest::Unit::TestCase
     end
   end
 
+  def test_assert_equal_different_diff_raises
+    MiniTest::Assertions.stub(:diff, lambda { raise Errno::ENOENT }) do
+      util_assert_triggered "Expected: 1\n  Actual: 2" do
+        @tc.assert_equal 1, 2
+      end
+    end
+  end
+
   def test_assert_equal_different_hex
     c = Class.new do
       def initialize s; @name = s; end


### PR DESCRIPTION
This is an attempt to fail gracefully when shelling out to diff raises.

Saw a report of Errno::ENOENT being raised on Windows because diff.exe was missing from their system. This tries to fix that.

Here is the tweet that I saw: https://twitter.com/Cumbayah/status/290926239047376896
