### PR TITLE
Document that record can be sent twice if teardown fails or errors

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -926,7 +926,7 @@ module MiniTest
     end
 
     ##
-    # Record the result of a single run. Makes it very easy to gather
+    # Record the result of a single test. Makes it very easy to gather
     # information. Eg:
     #
     #   class StatisticsRecorder < MiniTest::Unit
@@ -936,6 +936,11 @@ module MiniTest
     #   end
     #
     #   MiniTest::Unit.runner = StatisticsRecorder.new
+    #
+    # NOTE: record might be sent more than once per test.  It will be
+    # sent once with the results from the test itself.  If there is a
+    # failure or error in teardown, it will be sent again with the
+    # error or failure.
 
     def record suite, method, assertions, time, error
     end


### PR DESCRIPTION
This is just a doc cleanup resulting from the way #221 was fixed.
