### PR TITLE
Allow filtering tests by suite name as well as test name

### DIFF
--- a/lib/minitest/parallel_each.rb
+++ b/lib/minitest/parallel_each.rb
@@ -27,6 +27,10 @@ class ParallelEach
     self.class.new super
   end
 
+  def select(&block)
+    self.class.new super
+  end
+
   ##
   # Starts N threads that yield each element to your block. Joins the
   # threads at the end.

--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -908,7 +908,9 @@ module MiniTest
       filter = options[:filter] || '/./'
       filter = Regexp.new $1 if filter =~ /\/(.*)\//
 
-      assertions = suite.send("#{type}_methods").grep(filter).map { |method|
+      all_test_methods = suite.send("#{type}_methods")
+      filtered_test_methods = all_test_methods.select { |m| "#{suite}##{m}".match(filter) }
+      assertions = filtered_test_methods.map { |method|
         inst = suite.new method
         inst._assertions = 0
 

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -389,6 +389,32 @@ class TestMiniTestRunner < MetaMetaMetaTestCase
     assert_report expected, %w[--name /some|thing/ --seed 42]
   end
 
+  def test_run_filtered_including_suite_name
+    alpha = Class.new MiniTest::Unit::TestCase do
+      def test_something
+        assert false
+      end
+    end
+    self.class.const_set(:Alpha, alpha)
+
+    beta = Class.new MiniTest::Unit::TestCase do
+      def test_something
+        assert true
+      end
+    end
+    self.class.const_set(:Beta, beta)
+
+    expected = clean <<-EOM
+      .
+
+      Finished tests in 0.00
+
+      1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
+    EOM
+
+    assert_report expected, %w[--name /Beta#test_something/ --seed 42]
+  end
+
   def test_run_passing
     Class.new MiniTest::Unit::TestCase do
       def test_something


### PR DESCRIPTION
Previous to this commit, it is only possibly to filter by parts of
the test name. However, it's possible for multiple suites to be
loaded at the same time, and these may validly define tests with the
same name.

This change allows the specified filter to match against the suite
name as well as the test name, which should make it possible to
unambiguously run a single test from a set of test suites.
