### PR TITLE
* lib/minitest/mock.rb: nodoc top-level module

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -4,7 +4,7 @@ end # omg... worst bug ever. rdoc doesn't allow 1-liners
 ##
 # A simple and clean mock object framework.
 
-module MiniTest
+module MiniTest # :nodoc:
 
   ##
   # All mock objects are an instance of Mock


### PR DESCRIPTION
Merging r39020 from ruby-trunk

There is some wonkyness going on with the MiniTest docs, see ruby-doc.org:
- [benchmark](http://ruby-doc.org/stdlib-2.0/libdoc/minitest/benchmark/rdoc/index.html)
- [mock](http://ruby-doc.org/stdlib-2.0/libdoc/minitest/mock/rdoc/index.html)
- [spec](http://ruby-doc.org/stdlib-2.0/libdoc/minitest/spec/rdoc/index.html)
- [unit](http://ruby-doc.org/stdlib-2.0/libdoc/minitest/unit/rdoc/index.html)

MiniTest::Unit is the only one that looks decent because it includes README.txt

I realize you have your own docs generated on seattlerb.org, but a lot of people use ruby-doc.org, it's the third result for ["minitest documentation"](https://www.google.com/search?q=minitest+documentation).
