### PR TITLE
Support for public_send and send calls to mocks

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -11,7 +11,7 @@ module MiniTest # :nodoc:
   class Mock
     alias :__respond_to? :respond_to?
 
-    skip_methods = %w(object_id respond_to_missing? inspect === to_s)
+    skip_methods = %w(object_id respond_to_missing? inspect === to_s public_send send)
 
     instance_methods.each do |m|
       undef_method m unless skip_methods.include?(m.to_s) || m =~ /^__/

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -259,6 +259,26 @@ class TestMiniTestMock < MiniTest::Unit::TestCase
     assert_equal rs, 32
   end
 
+  def test_mock_respects_public_send
+    mock = MiniTest::Mock.new
+    mock.expect(:foo, 13, [42])
+
+    rs = mock.public_send(:foo, 42)
+
+    assert_equal rs, 13
+    assert mock.verify
+  end
+
+  def test_mock_respects_send
+    mock = MiniTest::Mock.new
+    mock.expect(:foo, 13, [42])
+
+    rs = mock.send(:foo, 42)
+
+    assert_equal rs, 13
+    assert mock.verify
+  end
+
   def util_verify_bad exp
     e = assert_raises MockExpectationError do
       @mock.verify


### PR DESCRIPTION
Whilst using MiniTest::Mock to make expectations on code that invokes methods dynamically, I've found myself being forced to use `__send__` instead of the privacy-safe `public_send` I'd prefer to use in most situations. This patch rectifies this by adding `send` and `public_send` to the list of skipped methods in MiniTest::Mock.

Let me know what you think. I'm unsure as to whether you'd want some negative tests in there as well as the positive ones I used to drive these changes. For example, you might want a corresponding `test_blow_up_if_not_called_when_using_send`. I'd be happy to add these if desired.

It's also possible that people would want to put expectations on these methods directly (for better or worse).

Andrew
