### PR TITLE
move info signal handling into runner; make optional by way of accessor.

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -736,6 +736,17 @@ module MiniTest
     attr_writer   :options                            # :nodoc:
 
     ##
+    # :attr:
+    #
+    # if true, installs an "INFO" signal handler (only available to BSD and
+    # OS X users) which prints diagnostic information about the test run.
+    #
+    # This is auto-detected by default but may be overridden by custom
+    # runners.
+
+    attr_accessor :set_info_signal
+
+    ##
     # Lazy accessor for options.
 
     def options
@@ -977,6 +988,7 @@ module MiniTest
       @errors = @failures = @skips = 0
       @verbose = false
       @mutex = defined?(Mutex) ? Mutex.new : nil
+      @set_info_signal = Signal.list['INFO']
     end
 
     def synchronize # :nodoc:
@@ -1210,8 +1222,6 @@ module MiniTest
       PASSTHROUGH_EXCEPTIONS = [NoMemoryError, SignalException,
                                 Interrupt, SystemExit] # :nodoc:
 
-      SUPPORTS_INFO_SIGNAL = Signal.list['INFO'] # :nodoc:
-
       ##
       # Runs the tests reporting the status to +runner+
 
@@ -1224,7 +1234,7 @@ module MiniTest
           time = runner.start_time ? Time.now - runner.start_time : 0
           warn "Current Test: %s#%s %.2fs" % [self.class, self.__name__, time]
           runner.status $stderr
-        end if SUPPORTS_INFO_SIGNAL
+        end if runner.set_info_signal
 
         start_time = Time.now
 
@@ -1258,7 +1268,7 @@ module MiniTest
               result = runner.puke self.class, self.__name__, e
             end
           end
-          trap 'INFO', 'DEFAULT' if SUPPORTS_INFO_SIGNAL
+          trap 'INFO', 'DEFAULT' if runner.set_info_signal
         end
         result
       end


### PR DESCRIPTION
Here's a solution for #207. Moves the info signal handling to the runner and makes it a toggle, detected by default.

Here's some example code that exhibits how it might be used, other bits are immaterial and just add context, but might be familiar if you remember our conversation about suite hooks.

``` ruby
class MiniTest::Unit::ProvisionedRunner < MiniTest::Unit
  def _run_suite(suite, type)
    begin
      suite.before_suite unless suite.test_methods.empty?
      super(suite, type)
    ensure
      suite.after_suite unless suite.test_methods.empty?
    end
  end
end

MiniTest::Unit.runner = MiniTest::Unit::ProvisionedRunner.new
MiniTest::Unit.runner.set_info_signal = false
```
