### PR TITLE
add stub_any_instance method

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -190,4 +190,28 @@ class Object # :nodoc:
     metaclass.send :alias_method, name, new_name
     metaclass.send :undef_method, new_name
   end
+
+  def self.stub_any_instance name, val_or_callable, &block
+    new_name = "__minitest_any_instance_stub__#{name}"
+
+    class_eval do
+      alias_method new_name, name
+
+      define_method(name) do |*args|
+        if val_or_callable.respond_to? :call then
+          val_or_callable.call(*args)
+        else
+          val_or_callable
+        end
+      end
+    end
+
+    yield
+  ensure
+    class_eval do
+      undef_method name
+      alias_method name, new_name
+      undef_method new_name
+    end
+  end
 end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -367,3 +367,42 @@ class TestMiniTestStub < MiniTest::Unit::TestCase
     @tc.assert_equal false, dynamic.found
   end
 end
+
+class TestMiniTestAnyInstanceStub < MiniTest::Unit::TestCase
+  parallelize_me!
+
+  def setup
+    super
+    MiniTest::Unit::TestCase.reset
+
+    @tc = MiniTest::Unit::TestCase.new 'fake tc'
+    @assertion_count = 1
+  end
+
+  def teardown
+    super
+    assert_equal @assertion_count, @tc._assertions
+  end
+
+  def assert_stub val_or_callable
+    @assertion_count += 1
+
+    synchronize do
+      obj = "foo"
+
+      String.stub_any_instance :size, val_or_callable do
+        @tc.assert_equal 42, obj.size
+      end
+
+      @tc.assert_operator obj.size, :==, 3
+    end
+  end
+
+  def test_stub_value
+    assert_stub 42
+  end
+
+  def test_stub_block
+    assert_stub lambda { 42 }
+  end
+end


### PR DESCRIPTION
Because sometimes we want to stub some method on all instances of the class.
@zenspider wdyt? Should this be in minitest or it can live as a helper or something? (we have it as helper already in [SimpleForm](https://github.com/plataformatec/simple_form/blob/master/test/support/misc_helpers.rb#L27))
