### PR TITLE
Ensure spec names are correct

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -242,20 +242,24 @@ class MiniTest::Spec < MiniTest::Unit::TestCase
       cls
     end
 
+    def name # :nodoc:
+      defined?(@name) ? @name : super
+    end
+
+    # Can't alias due to 1.8.7, not sure why
+    def to_s # :nodoc:
+      name
+    end
+
     # :stopdoc:
     attr_reader :desc
     alias :specify :it
-    alias :name :to_s
     # :startdoc:
   end
 
   extend DSL
 
   TYPES = DSL::TYPES
-
-  def self.to_s # :nodoc:
-    defined?(@name) ? @name : super
-  end
 end
 
 ##

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -3,7 +3,11 @@ require "minitest/autorun"
 require "stringio"
 
 class MiniSpecA < MiniTest::Spec; end
-class MiniSpecB < MiniTest::Spec; end
+class MiniSpecB < MiniTest::Unit::TestCase; extend MiniTest::Spec::DSL; end
+class MiniSpecC < MiniSpecB; end
+class NamedExampleA < MiniSpecA; end
+class NamedExampleB < MiniSpecB; end
+class NamedExampleC < MiniSpecC; end
 class ExampleA; end
 class ExampleB < ExampleA; end
 
@@ -648,6 +652,18 @@ class TestMeta < MiniTest::Unit::TestCase
     assert_equal MiniSpecB, MiniTest::Spec.spec_type(ExampleB)
   ensure
     MiniTest::Spec::TYPES.replace original_types
+  end
+
+  def test_name
+    assert_equal "NamedExampleA", NamedExampleA.name
+    assert_equal "NamedExampleB", NamedExampleB.name
+    assert_equal "NamedExampleC", NamedExampleC.name
+
+    spec_a = describe ExampleA do; end
+    spec_b = describe ExampleB, :random_method do; end
+
+    assert_equal "ExampleA", spec_a.name
+    assert_equal "ExampleB::random_method", spec_b.name
   end
 
   def test_structure


### PR DESCRIPTION
Without this change I'm seeing spec names as "#<Class:0x007ff82406a170>", which blocks minitest-rails from being able to resolve the model/controller/mailer/etc from the spec name.
