### PR TITLE
Fix 1.8 DSL#name bug.

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -243,13 +243,16 @@ class MiniTest::Spec < MiniTest::Unit::TestCase
     end
 
     def to_s # :nodoc:
-      defined?(@name) ? @name : (super rescue "dunno") # rescue is a 1.8 oddity
+      defined?(@name) ? @name : super
+    end
+
+    def name # :nodoc:
+      defined?(@name) ? @name : super
     end
 
     # :stopdoc:
     attr_reader :desc
     alias :specify :it
-    alias :name :to_s
     # :startdoc:
   end
 

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -6,6 +6,8 @@ class MiniSpecA < MiniTest::Spec; end
 class MiniSpecB < MiniTest::Spec; end
 class ExampleA; end
 class ExampleB < ExampleA; end
+class DslExampleA; extend MiniTest::Spec::DSL; end
+class DslExampleB < DslExampleA; end
 
 describe MiniTest::Spec do
   # do not parallelize this suite... it just can"t handle it.
@@ -656,6 +658,11 @@ class TestMeta < MiniTest::Unit::TestCase
 
     assert_equal "ExampleA", spec_a.name
     assert_equal "ExampleB::random_method", spec_b.name
+  end
+
+  def test_dsl_name
+    assert_equal "DslExampleA", DslExampleA.name
+    assert_equal "DslExampleB", DslExampleB.name
   end
 
   def test_structure


### PR DESCRIPTION
As mentioned in issue #28, the DSL usage breaks in 1.8, so in order to get minitest-spec-rails and others working for 1.8 using the DSL module, we need a working #name method that does not return `"dunno"`. This code illustrates how `alias` will not work in 1.8 for #name while the pull request works around this 1.8 oddity.

``` ruby
module DSL
  def to_s
    super
  end
  alias :name :to_s
end

class Bar
  extend DSL
end

puts Bar.to_s
puts Bar.name # dsl_fail.rb:3:in `name': super: no superclass method `to_s' for Bar:Class (NoMethodError)
              # from dsl_fail.rb:13
```
