### PR TITLE
Fixed assert_in_delta.

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -232,7 +232,7 @@ module MiniTest
     def assert_in_delta exp, act, delta = 0.001, msg = nil
       n = (exp - act).abs
       msg = message(msg) { "Expected |#{exp} - #{act}| (#{n}) to be < #{delta}"}
-      assert delta >= n, msg
+      assert delta > n, msg
     end
 
     ##

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -921,6 +921,12 @@ class TestMiniTestUnitTestCase < MiniTest::Unit::TestCase
     @tc.assert_in_delta 0.0, 1.0 / 1000, 0.1
   end
 
+  def test_assert_in_delta_triggered_for_equal_delta
+    util_assert_triggered "Expected |6.0 - 5.0| (1.0) to be < 1.0." do
+      @tc.assert_in_delta 6.0, 5.0, 1.0
+    end
+  end
+
   def test_assert_in_delta_triggered
     x = maglev? ? "9.9999999999999995e-07" : "1.0e-06"
     util_assert_triggered "Expected |0.0 - 0.001| (0.001) to be < #{x}." do


### PR DESCRIPTION
I've tried to change expectations messages first, but as i can see in assert_in_epsilon comment, it should be less, not less or equal. Maybe someday somebody will use this expectations (in_delta, in_epsilon) for integers too.
