### PR TITLE
Add size method to ParallelEach

### DIFF
--- a/lib/minitest/parallel_each.rb
+++ b/lib/minitest/parallel_each.rb
@@ -44,6 +44,8 @@ class ParallelEach
     }
     threads.map(&:join)
   end
+
+  alias_method :size, :count
 end
 
 module Minitest

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -476,6 +476,10 @@ class TestMinitestRunner < MetaMetaMetaTestCase
     end
   end
 
+  def test_parallel_each_size
+    assert_equal 0, ParallelEach.new([]).size
+  end
+
   def test_run_parallel
     skip "I don't have ParallelEach debugged yet" if maglev?
 


### PR DESCRIPTION
When I run `PARALLEL=true make test-all TESTS=test/minitest/test_minitest_unit.rb` on trunk ruby, I get this exception:

```
/Users/btaitelb/programming/ruby/ruby/lib/test/unit.rb:707:in `block in _prepare_run': undefined method `size' for #<ParallelEach:0x007f873398ea38> (NoMethodError)
    from /Users/btaitelb/programming/ruby/ruby/lib/test/unit.rb:707:in `each'
    from /Users/btaitelb/programming/ruby/ruby/lib/test/unit.rb:707:in `inject'
    from /Users/btaitelb/programming/ruby/ruby/lib/test/unit.rb:707:in `_prepare_run'
    from /Users/btaitelb/programming/ruby/ruby/lib/test/unit.rb:648:in `_run_suites'
    from /Users/btaitelb/programming/ruby/ruby/lib/minitest/unit.rb:867:in `_run_anything'
    from /Users/btaitelb/programming/ruby/ruby/lib/minitest/unit.rb:1060:in `run_tests'
    from /Users/btaitelb/programming/ruby/ruby/lib/minitest/unit.rb:1047:in `block in _run'
    from /Users/btaitelb/programming/ruby/ruby/lib/minitest/unit.rb:1046:in `each'
    from /Users/btaitelb/programming/ruby/ruby/lib/minitest/unit.rb:1046:in `_run'
    from /Users/btaitelb/programming/ruby/ruby/lib/minitest/unit.rb:1035:in `run'
    from /Users/btaitelb/programming/ruby/ruby/lib/test/unit.rb:21:in `run'
    from /Users/btaitelb/programming/ruby/ruby/lib/test/unit.rb:774:in `run'
    from /Users/btaitelb/programming/ruby/ruby/lib/test/unit.rb:834:in `run'
    from /Users/btaitelb/programming/ruby/ruby/lib/test/unit.rb:838:in `run'
    from ./test/runner.rb:17:in `<main>'
make: *** [yes-test-all] Error 1
```

Test::Unit calls #size on the ParallelEach.
