### PR TITLE
exit code for #276

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -40,7 +40,7 @@ module Minitest
 
       at_exit {
         @@after_run.reverse_each(&:call)
-        exit exit_code
+        exit(exit_code || 1)
       }
 
       exit_code = Minitest.run ARGV


### PR DESCRIPTION
exit code for #276

Hi...

I hope this little fix is the expected behaviour.

Before:

```
$ ruby foo.rb -z
MiniTest::Unit::TestCase is now Minitest::Test. From foo.rb:13:in `<main>'

invalid option: -z

minitest options:
    -h, --help                       Display this help.
    -s, --seed SEED                  Sets random seed
    -v, --verbose                    Verbose. Show progress processing files.
    -p, --pride                      Pride. Show your testing pride!
    -n, --name PATTERN               Filter method names on pattern (e.g. /foo/)
/usr/local/lib/ruby/gems/2.0.0/gems/minitest-5.0.0/lib/minitest.rb:43:in `exit': no implicit conversion from nil to integer (TypeError)
    from /usr/local/lib/ruby/gems/2.0.0/gems/minitest-5.0.0/lib/minitest.rb:43:in `block (2 levels) in autorun'
```

After:

```
$ ruby foo.rb -z
MiniTest::Unit::TestCase is now Minitest::Test. From foo.rb:13:in `<main>'

invalid option: -z

minitest options:
    -h, --help                       Display this help.
    -s, --seed SEED                  Sets random seed
    -v, --verbose                    Verbose. Show progress processing files.
    -p, --pride                      Pride. Show your testing pride!
    -n, --name PATTERN               Filter method names on pattern (e.g. /foo/)
```

I hope this helps.
`^_^` Yup.
