### PR TITLE
failed? && error_occurred? methods added to Runnable

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -342,9 +342,9 @@ module Minitest
     end
 
     ##
-    # If there was unexpected error during test run.
+    # Did this run error?
 
-    def error_occurred?
+    def error?
       raise NotImplementedError, "subclass responsibility"
     end
   end
@@ -450,7 +450,7 @@ module Minitest
 
     def report
       f = results.count(&:failed?)
-      e = results.count(&:error_occurred?)
+      e = results.count(&:error?)
       s = results.count(&:skipped?)
       t = Time.now - start_time
 

--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -253,14 +253,7 @@ module Minitest
     # Was this run failed due to assertion?
 
     def failed?
-      not (passed? or skipped? or error_occurred?)
-    end
-
-    ##
-    # If there was unexpected error during test run.
-
-    def error_occurred?
-      self.failure and UnexpectedError === self.failure
+      not (passed? or skipped? or error?)
     end
 
     def time_it # :nodoc:


### PR DESCRIPTION
These methods complete test status' encapsulation
and reporters should use them to check Runnable's status.
