### PR TITLE
output failing tests on INFO trap

### DIFF
--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -270,14 +270,15 @@ module Minitest
 
       t0 = Time.now
 
-      trap "INFO" do
+      old_trap = trap("INFO") do
         warn ""
+        old_trap.call if old_trap
         warn "Current: %s#%s %.2fs" % [self.class, self.name, Time.now - t0]
       end if supports_info_signal
 
       yield
     ensure
-      trap "INFO", "DEFAULT" if supports_info_signal
+      trap "INFO", old_trap if supports_info_signal
     end
 
     include LifecycleHooks


### PR DESCRIPTION
I miss seeing the failing tests on the info trap.  This commit adds them back (but I don't know how to test it)
