### PR TITLE
Enable mock expectations to set on === method

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -141,6 +141,11 @@ module Minitest # :nodoc:
       return true if @expected_calls.has_key?(sym.to_sym)
       return __respond_to?(sym, include_private)
     end
+
+    def ===(other)
+      return method_missing(:===, other) if @expected_calls.has_key?(:===)
+      return super
+    end
   end
 end
 

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -74,6 +74,16 @@ class TestMinitestMock < Minitest::Test
     assert mock.verify
   end
 
+  def test_set_expectation_on_threequals
+    mock = Minitest::Mock.new
+    arg = Object.new
+
+    mock.expect(:===, true, [ arg ])
+    mock.===(arg)
+
+    assert mock.verify
+  end
+
   def test_blow_up_on_wrong_arguments
     @mock.foo
     @mock.meaning_of_life


### PR DESCRIPTION
I have a scenario where I have to validate against a Regex or arbitrary function so I'm passing a `Regex` or lambda and sending `===` to the format object.

I don't see that it's current possible to test this behaviour with a `Minitest::Mock` as you cannot set an expectation for the `===` message.

In this PR I have copied the example set by the `respond_to?` method and made a it a special case.
