### PR TITLE
Allow mock expectations to be satisfied with #send

### DIFF
--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -74,6 +74,47 @@ class TestMinitestMock < Minitest::Test
     assert mock.verify
   end
 
+  def test_set_expectation_on_retained_methds
+    mock = Minitest::Mock.new
+
+    mock.expect(:object_id, "received object_id")
+    assert_equal "received object_id", mock.object_id
+
+    mock.expect(:respond_to_missing?, "received respond_to_missing?")
+    assert_equal "received respond_to_missing?", mock.respond_to_missing?
+
+    mock.expect(:===, "received ===")
+    assert_equal "received ===", mock.===
+
+    mock.expect(:inspect, "received inspect")
+    assert_equal "received inspect", mock.inspect
+
+    mock.expect(:to_s, "received to_s")
+    assert_equal "received to_s", mock.to_s
+
+    mock.expect(:public_send, "received public_send")
+    assert_equal "received public_send", mock.public_send
+
+    mock.expect(:send, "received send")
+    assert_equal "received send", mock.send
+
+    assert mock.verify
+  end
+
+  def test_expectations_can_be_satisfied_via_send
+    @mock.send(:foo)
+    @mock.send(:meaning_of_life)
+
+    assert @mock.verify
+  end
+
+  def test_expectations_can_be_satisfied_via_public_send
+    @mock.public_send(:foo)
+    @mock.public_send(:meaning_of_life)
+
+    assert @mock.verify
+  end
+
   def test_blow_up_on_wrong_arguments
     @mock.foo
     @mock.meaning_of_life


### PR DESCRIPTION
Expectations set on Minitest::Mock cannot be satisfied with #send or #public_send

If your application is calling a method via `#send` or `#public_send` it may not be desirable for your tests to mirror this implementation detail.

You may want just set an expectation for `#foo` and then `object.public_send(:foo)` allowing you to change the implementation of how `#foo` is called without changing the tests.

The implementation also has the advantage that inherited methods (from Object) that are not removed can also have expectations set on them, they of course behave normally otherwise.

This also solves the issue raised in #302 which enables expectations on `#===`.
