### PR TITLE
let blocks defined in Minitest::Spec files will be unintentionally run as tests

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -222,6 +222,7 @@ class Minitest::Spec < Minitest::Test
     # Why use let instead of def? I honestly don't know.
 
     def let name, &block
+      raise ArgumentError, 'name cannot begin with "test"' if name.to_s =~ /\Atest/
       define_method name do
         @_memoized ||= {}
         @_memoized.fetch(name) { |k| @_memoized[k] = instance_eval(&block) }

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -551,6 +551,12 @@ describe Minitest::Spec, :let do
 
     _count.must_equal 2
   end
+
+  it 'raises an error if the name begins with "test"' do
+    describe "let" do
+      proc { let(:test_value) { true } }.must_raise ArgumentError
+    end
+  end
 end
 
 describe Minitest::Spec, :subject do


### PR DESCRIPTION
I suspect that this owes to the way you define tests in Minitest::Test and Test::Unit before it, but if you define a `let` in Minitest::Spec with a name that begins with `test_`, it will be inadvertently executed as one of the tests.  This can have unintended consequences.  Maybe `let` can just raise an error if called with a name that begins with `test_`?

``` ruby
require 'minitest/autorun'

describe "lets that can be run as tests" do
  let(:test_that_this_is_run_because_of_the_name) do
    puts "I ran"
  end
end
```
