### PR TITLE
Don't run if there was an exit with failure, i.e. exit(false).

### DIFF
--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -767,8 +767,8 @@ module MiniTest
 
     def self.autorun
       at_exit {
-        # don't run if there was a non-exit exception
-        next if $! and not $!.kind_of? SystemExit
+        # don't run if there was a non-exit exception or exit with failure
+        next if $! and (not $!.kind_of? SystemExit or !$!.success?)
 
         # the order here is important. The at_exit handler must be
         # installed before anyone else gets a chance to install their


### PR DESCRIPTION
This happens e.g. when there's a syntax error in a test file, and rake catches the error and calls `exit(false)` (in `Rake::Application#exit_because_of_exception`).  Without this fix, Minitest goes on to run all the tests that it had successfully loaded before the error, and finishes by saying there were no failures or errors.
