### PR TITLE
Fix syntax error in example code

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -42,7 +42,7 @@ module Minitest # :nodoc:
     #   @mock.uses_any_string("foo") # => true
     #   @mock.verify  # => true
     #
-    #   @mock.expect(:uses_one_string, true, ["foo"]
+    #   @mock.expect(:uses_one_string, true, ["foo"])
     #   @mock.uses_one_string("bar") # => true
     #   @mock.verify  # => raises MockExpectationError
 


### PR DESCRIPTION
Example in MiniTest::Mock#expect is missing a close parenthesis.
