### PR TITLE
Missing ")" on mock's rdoc

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -42,7 +42,7 @@ module Minitest # :nodoc:
     #   @mock.uses_any_string("foo") # => true
     #   @mock.verify  # => true
     #
-    #   @mock.expect(:uses_one_string, true, ["foo"]
+    #   @mock.expect(:uses_one_string, true, ["foo"])
     #   @mock.uses_one_string("bar") # => true
     #   @mock.verify  # => raises MockExpectationError
 


### PR DESCRIPTION
Hello there!
Just fixing a typo. it's all i can do at this time.
i hope i can help more in the future.
