### PR TITLE
require 'minitest' for people who need 'minitest/test' directly.

### DIFF
--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -1,3 +1,5 @@
+require 'minitest'
+
 module Minitest
   ##
   # Subclass Test to create your own tests. Typically you'll want a


### PR DESCRIPTION
hey ryan,

this fixes an issue where requiring minitest/test directly does not require minitest, so it blows up depending on runnable.

I'm not 100% sure if this is how you want the library to be used, but I figured it was worth sending along the pull request. Currently porting to minitest 5 so I'm running into these kinds of issues.

Thanks again for a great library.

-Erik
