### PR TITLE
Replace remaining references to miniunit

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 # -*- ruby -*-
 
-$TESTING_MINIUNIT = true
-
 require 'rubygems'
 require 'hoe'
 
@@ -72,7 +70,7 @@ end
 desc "stupid line count"
 task :dickwag do
   puts
-  puts "miniunit"
+  puts "minitest"
   puts
   print " lib  loc"; loc "lib"
   print " test loc"; loc "test"


### PR DESCRIPTION
There were a couple of old references to miniunit, plus a seemingly unused global variable. It fixes part of `rake dickwag`, but doesn't fix the task itself since I'm not entirely certain what this folder would contain (and it doesn't work with `ENV['RUBY_ROOT']`): `Dir.chdir File.expand_path("~/Work/svn/ruby/ruby_1_8")`
