### PR TITLE
Add describe block names to test method names so that selecting tests via -n is more useful

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -205,7 +205,10 @@ class Minitest::Spec < Minitest::Test
       @specs ||= 0
       @specs += 1
 
-      name = "test_%04d_%s" % [ @specs, desc ]
+      nested_describes = describe_stack.dup.tap { |s| s.shift }
+      name_parts = nested_describes.map { |d| d.desc }
+      name_parts << desc
+      name = "test_%04d_%s" % [ @specs, name_parts.join(" ") ]
 
       define_method name, &block
 

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -692,14 +692,16 @@ class TestMeta < MetaMetaMetaTestCase
     assert_equal "inner thingy",      y.desc
     assert_equal "very inner thingy", z.desc
 
-    top_methods = %w(setup teardown test_0001_top-level-it)
-    inner_methods1 = %w(setup teardown test_0001_inner-it)
-    inner_methods2 = inner_methods1 +
-      %w(test_0002_anonymous test_0003_anonymous)
+    top_methods = ["setup", "teardown", "test_0001_top-level-it"]
+    inner_methods_1 = ["setup", "teardown", "test_0001_inner thingy inner-it"]
+    inner_methods_2 = ["setup", "teardown",
+                       "test_0001_inner thingy very inner thingy inner-it",
+                       "test_0002_inner thingy very inner thingy anonymous",
+                       "test_0003_inner thingy very inner thingy anonymous"]
 
-    assert_equal top_methods,    x.instance_methods(false).sort.map(&:to_s)
-    assert_equal inner_methods1, y.instance_methods(false).sort.map(&:to_s)
-    assert_equal inner_methods2, z.instance_methods(false).sort.map(&:to_s)
+    assert_equal top_methods,     x.instance_methods(false).sort.map(&:to_s)
+    assert_equal inner_methods_1, y.instance_methods(false).sort.map(&:to_s)
+    assert_equal inner_methods_2, z.instance_methods(false).sort.map(&:to_s)
   end
 
   def test_setup_teardown_behavior


### PR DESCRIPTION
If you use `minitest/spec` with nested `describe` blocks, it becomes difficult to select tests by name since the describe block's name is not included in the generated method name. Example:

``` ruby
describe Class do
  describe "case A" do
    it "is correct" {}
  end

  describe "case B" do
    it "is correct" {}
  end
end
```

**Before patch**
Runs no tests: `ruby test.rb --name "/case A is correct/"`
Runs no tests: `ruby test.rb --name "/case B is correct/"`
Runs no tests: `ruby test.rb --name "/case/"`
Runs both tests: `ruby test.rb --name "/correct/"`

**After patch**
Runs first test: `ruby test.rb --name "/case A is correct/"`
Runs second test: `ruby test.rb --name "/case B is correct/"`
Runs both tests: `ruby test.rb --name "/case/"`
Runs both tests: `ruby test.rb --name "/correct/"`
