### PR TITLE
Add named subject.

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -234,8 +234,8 @@ class Minitest::Spec < Minitest::Test
     # Another lazy man's accessor generator. Made even more lazy by
     # setting the name for you to +subject+.
 
-    def subject &block
-      let :subject, &block
+    def subject name = :subject, &block
+      let name, &block
     end
 
     def create name, desc # :nodoc:

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -562,16 +562,32 @@ end
 describe Minitest::Spec, :subject do
   attr_reader :subject_evaluation_count
 
-  subject do
-    @subject_evaluation_count ||= 0
-    @subject_evaluation_count  += 1
-    @subject_evaluation_count
+  describe 'un-named subject' do
+    subject do
+      @subject_evaluation_count ||= 0
+      @subject_evaluation_count  += 1
+      @subject_evaluation_count
+    end
+
+    it "is evaluated once per example" do
+      subject.must_equal 1
+      subject.must_equal 1
+      subject_evaluation_count.must_equal 1
+    end
   end
 
-  it "is evaluated once per example" do
-    subject.must_equal 1
-    subject.must_equal 1
-    subject_evaluation_count.must_equal 1
+  describe 'named subject' do
+    subject :random_name do
+      @subject_evaluation_count ||= 0
+      @subject_evaluation_count  += 1
+      @subject_evaluation_count
+    end
+
+    it "is available under the provided name" do
+      random_name.must_equal 1
+      random_name.must_equal 1
+      subject_evaluation_count.must_equal 1
+    end
   end
 end
 


### PR DESCRIPTION
As discussed with @zenspider at GoGaRuCo.

RSpec allows a name to be given when declaring a subject. This works exactly like simply declaring a `let` with the same name.  This PR adds that functionality.

Background information:

http://betterspecs.org/#subject
http://blog.davidchelimsky.net/blog/2012/05/14/spec-smell-explicit-use-of-subject/ (in Update 2012-05-15 section at bottom)
