### PR TITLE
Include minitest-stub_any_instance under known extensions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -425,6 +425,7 @@ minitest-spec-context       :: Provides rspec-ish context method to MiniTest::Sp
 minitest-spec-expect        :: Expect syntax for MiniTest::Spec - expect(sequences).to_include :celery_man
 minitest-spec-magic         :: Minitest::Spec extensions for Rails and beyond
 minitest-spec-rails         :: Drop in MiniTest::Spec superclass for ActiveSupport::TestCase.
+minitest-stub_any_instance  :: Stub any instance of a method on the given class for the duration of a block
 minitest-stub-const         :: Stub constants for the duration of a block
 minitest-tags               :: add tags for minitest
 minitest-wscolor            :: Yet another test colorizer.


### PR DESCRIPTION
The [pull request to add this to minitest](https://github.com/seattlerb/minitest/pull/245) was denied, but @zenspider said it would be suitable as a gem. @nashby declined, but I felt it was worthy enough to package the code for others' easy reuse.

[gem on rubygems.org](http://rubygems.org/gems/minitest-stub_any_instance)
[code on github](https://github.com/codeodor/minitest-stub_any_instance)
