### PR TITLE
Add context as alias to describe.

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -72,7 +72,8 @@ module Kernel # :nodoc:
     stack.pop
     cls
   end
-  private :describe
+  alias :context :describe
+  private :describe, :context
 end
 
 ##

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -734,6 +734,26 @@ class TestMeta < MetaMetaMetaTestCase
     assert_equal [], z.instance_methods.grep(/^test/)
   end
 
+  def test_mixed_describe_context_structure
+    x = x1 = x2 = y = z = nil
+    x = describe "top-level thingy" do
+      x1 = it "top level it" do end
+
+      y = context "first thingy" do
+        x2 = it "nested under context" do end
+      end
+      z = context "second thingy" do end
+    end
+
+    test_methods = ["test_0001_top level it", "test_0001_nested under context"]
+
+    assert_equal test_methods, [x1, x2]
+    assert_equal [test_methods.first],
+      x.instance_methods.grep(/^test/).map {|o| o.to_s}.sort
+    assert_equal [test_methods.last.to_sym], y.instance_methods.grep(/^test/)
+    assert_equal [], z.instance_methods.grep(/^test/)
+  end
+
   def test_structure_subclasses
     z = nil
     x = Class.new Minitest::Spec do


### PR DESCRIPTION
I have been attempting to convert my team to use Minitest and this has been a bit of a stumbling block for them. It really _shouldn't_ matter, but this wasn't hard to implement or test.

Many `rspec'ers use a top-level`describe`then use`context` to contain the actual tests.

See: http://betterspecs.org/#contexts for an example.
