### PR TITLE
Don't remove command line arguments when minitest is done parsing them

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -188,7 +188,7 @@ module Minitest
       end
 
       begin
-        opts.parse! args
+        opts.parse args
       rescue OptionParser::InvalidOption => e
         puts
         puts e


### PR DESCRIPTION
opts.parse! removes all the switches from ARGV, preventing anything running on minitest from seeing them. Removing the bang allows things running on top of minitest to be a little more flexible, and see command line arguments.
