### PR TITLE
Unmock :tap

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -17,6 +17,7 @@ module Minitest # :nodoc:
       public_send
       respond_to_missing?
       send
+      tap
       to_s
     )
 

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -98,6 +98,9 @@ class TestMinitestMock < Minitest::Test
     mock.expect :send, "received send"
     assert_equal "received send", mock.send
 
+    mock.expect :tap, "received tap"
+    assert_equal "received tap", mock.tap
+
     assert mock.verify
   end
 


### PR DESCRIPTION
I would like to use my mocks around my tests, but still keping them DRY.
So, I propose to "unmock" `:tap` from [mock.rb](https://github.com/seattlerb/minitest/blob/master/lib/minitest/mock.rb) so a mock
can be used over any number of examples

``` ruby
def my_mock
  @my_mock ||= Minitest::Mock.new.tap do |klass|
    klass.expect(:foo, 'mocked-value', ['arbitrary-argument'])
  end
end
```

Without having to repeat:

``` ruby
my_mock = Minitest::Mock.new.tap
my_mock.expect(:foo, 'mocked-value', ['arbitrary-argument'])
```

over the examples to share that behaviour

I know that this can be accomplished by doing:

``` ruby
def my_mock
  return @my_mock if defined? @my_mock
  @my_mock = Minitest::Mock.new
  @my_mock.expect(:foo, 'mocked-value', ['arbitrary-argument'])
  @my_mock
end
```

but I don't see any drawbacks with "umocking" `:tap`.

Thoughts?
