### PR TITLE
Mock objects should respond to equal?

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -12,6 +12,7 @@ module Minitest # :nodoc:
 
     overridden_methods = %w(
       ===
+      equal?
       inspect
       object_id
       public_send

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -86,6 +86,9 @@ class TestMinitestMock < Minitest::Test
     mock.expect :===, "received ==="
     assert_equal "received ===", mock.===
 
+    mock.expect :equal?, "received equal?"
+    assert_equal "received equal?", mock.equal?
+
     mock.expect :inspect, "received inspect"
     assert_equal "received inspect", mock.inspect
 
@@ -99,6 +102,10 @@ class TestMinitestMock < Minitest::Test
     assert_equal "received send", mock.send
 
     assert mock.verify
+  end
+
+  def test_identity_equality_on_mock
+    assert @mock.equal?(@mock)
   end
 
   def test_expectations_can_be_satisfied_via_send


### PR DESCRIPTION
Currently equal? is being undefined on mock objects, meaning that mocks can't compare identity.  

equal? should not be undefined because it should essentially never be overridden by subclasses, as opposed to '==' which is commonly overridden.  Undefining this method causes surprising and undesirable behavior on Rubinius, as it explicitly uses the equal? method for comparing object identities (as opposed to a pointer comparison shortcut which is used by MRI and now JRuby as of 1.7.9).

An example of a spec that fails on Rubinius is:

```
it 'computes equality when using arrays containing Mintest::Mock objects' do
  item = Minitest::Mock.new
  item_array = [item]
  other_item_array = [item]
  assert_equal item_array, other_item_array
end
```

In this circumstance I don't see any reason why we should require the developer to mock 'equal?' or '==' on the item.  

Note that this is not a hypothetical case - the Rubinius specs for Sidekiq are failing for precisely this reason, as can be seen here - https://travis-ci.org/mperham/sidekiq/jobs/14995491
