### PR TITLE
Add my minitest-documentation implementation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -397,6 +397,7 @@ minitest-context            :: Defines contexts for code reuse in MiniTest
 minitest-debugger           :: Wraps assert so failed assertions drop into
                                the ruby debugger.
 minitest-display            :: Patches MiniTest to allow for an easily configurable output.
+minitest-documentation      :: Minimal documentation format inspired by rspec's
 minitest-doc_reporter       :: Detailed output inspired by rspec's documentation
                                format.
 minitest-emoji              :: Print out emoji for your test passes, fails, and skips.


### PR DESCRIPTION
This gem was built aimed to learn more about how `minitest` works under the hood(and because I missed the documentation format from `rspec`).

Versus `minitest-doc_format` this implementation is 86 LOC, instead of 160. Which gotta count for something
