### PR TITLE
Report test name before the test runs.

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -290,6 +290,7 @@ module Minitest
     end
 
     def self.run_one_method klass, method_name, reporter
+      reporter.start_one klass, method_name
       reporter.record Minitest.run_one_method(klass, method_name)
     end
 
@@ -399,6 +400,12 @@ module Minitest
     end
 
     ##
+    # Starts reporting on an individual test
+
+    def start_one klass, method_name
+    end
+
+    ##
     # Record a result and output the Runnable#result_code. Stores the
     # result of the run if the run did not pass.
 
@@ -446,9 +453,13 @@ module Minitest
   # own.
 
   class ProgressReporter < Reporter
+
+    def start_one klass, method_name
+      io.print "%s#%s = " % [klass, method_name] if options[:verbose]
+    end
+
     def record result # :nodoc:
-      io.print "%s#%s = %.2f s = " % [result.class, result.name, result.time] if
-        options[:verbose]
+      io.print "%.2f s = " % [result.time] if options[:verbose]
       io.print result.result_code
       io.puts if options[:verbose]
     end
@@ -606,6 +617,12 @@ module Minitest
 
     def start # :nodoc:
       self.reporters.each(&:start)
+    end
+
+    def start_one klass, method_name
+      self.reporters.each do |reporter|
+        reporter.start_one klass, method_name
+      end
     end
 
     def record result # :nodoc:

--- a/test/minitest/metametameta.rb
+++ b/test/minitest/metametameta.rb
@@ -22,7 +22,7 @@ class MetaMetaMetaTestCase < Minitest::Test
 
     reporter.start
 
-    yield(reporter) if block_given?
+    yield(reporter, @output) if block_given?
 
     @tus ||= [@tu]
     @tus.each do |tu|

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -432,6 +432,30 @@ class TestMinitestRunner < MetaMetaMetaTestCase
     assert_report expected, %w[--seed 42 --verbose]
   end
 
+  def test_run_verbose_with_breaking_output
+    output = nil
+    @tu =
+    Class.new Minitest::Test do
+      define_method :test_something do
+        output.puts "hi"
+        assert true
+      end
+    end
+
+    expected = clean <<-EOM
+      #<Class:0xXXX>#test_something = hi
+      0.00 s = .
+
+      Finished in 0.00
+
+      1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
+    EOM
+
+    assert_report expected, %w[--seed 42 --verbose] do |_, out|
+      output = out
+    end
+  end
+
   def test_run_with_other_runner
     @tu =
     Class.new Minitest::Test do


### PR DESCRIPTION
Having output split the reporting can be annoying, but the actual use
case is when a test is hanging, now we can see which test it is.
