### PR TITLE
allow multiple before and after blocks per spec

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -168,11 +168,9 @@ class Minitest::Spec < Minitest::Test
     #
     # Equivalent to Minitest::Test#setup.
 
-    def before type = nil, &block
-      define_method :setup do
-        super()
-        self.instance_eval(&block)
-      end
+
+    def before(type=nil, &block)
+      include Module.new { define_method(:setup) { super(); instance_exec(&block) } }
     end
 
     ##
@@ -183,10 +181,7 @@ class Minitest::Spec < Minitest::Test
     # Equivalent to Minitest::Test#teardown.
 
     def after type = nil, &block
-      define_method :teardown do
-        self.instance_eval(&block)
-        super()
-      end
+      include Module.new { define_method(:teardown) { instance_exec(&block); super() } }
     end
 
     ##

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -632,7 +632,9 @@ class TestMeta < MetaMetaMetaTestCase
 
       y = describe "inner thingy" do
         before { before_list << 2 }
+        before { before_list << 2.5 }
         after  { after_list  << 2 }
+        after  { after_list  << 2.5 }
         it "inner-it" do end
 
         z = describe "very inner thingy" do
@@ -712,8 +714,8 @@ class TestMeta < MetaMetaMetaTestCase
     assert_equal "inner thingy",      y.desc
     assert_equal "very inner thingy", z.desc
 
-    top_methods = %w(setup teardown test_0001_top-level-it)
-    inner_methods1 = %w(setup teardown test_0001_inner-it)
+    top_methods = %w(test_0001_top-level-it)
+    inner_methods1 = %w(test_0001_inner-it)
     inner_methods2 = inner_methods1 +
       %w(test_0002_anonymous test_0003_anonymous)
 
@@ -730,8 +732,8 @@ class TestMeta < MetaMetaMetaTestCase
     run_tu_with_fresh_reporter
 
     size = z.runnable_methods.size
-    assert_equal [1, 2, 3] * size, before_list
-    assert_equal [3, 2, 1] * size, after_list
+    assert_equal [1, 2, 2.5, 3] * size, before_list
+    assert_equal [3, 2.5, 2, 1] * size, after_list
   end
 
   def test_describe_first_structure


### PR DESCRIPTION
allows reusable helpers to define their own before/after blocks, so concerns can be wrapped in a helper (like setting up and tearing down fixtures/folders/stubs etc)

``` Ruby
def self.some_helper
  before { do some setup }
  after { do some teardown }
end

describe "xxx" do
  some_helper
  before { not overwriting the helpers before block }
end
```

@zenspider
