### PR TITLE
Be polite to users with order dependent tests

### DIFF
--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -19,14 +19,17 @@ module Minitest
 
     ##
     # Call this at the top of your tests when you absolutely
-    # positively need to have ordered tests. In doing so, you're
-    # admitting that you suck and your tests are weak.
+    # positively need to have ordered tests for example integration tests.
 
-    def self.i_suck_and_my_tests_are_order_dependent!
+    def self.tests_are_order_dependent!
       class << self
         undef_method :test_order if method_defined? :test_order
         define_method :test_order do :alpha end
       end
+    end
+
+    class << self
+      alias i_suck_and_my_tests_are_order_dependent! tests_are_order_dependent!
     end
 
     ##

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -523,7 +523,7 @@ describe Minitest::Spec do
 end
 
 describe Minitest::Spec, :let do
-  i_suck_and_my_tests_are_order_dependent!
+  tests_are_order_dependent!
 
   def _count
     $let_count ||= 0

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -1692,26 +1692,36 @@ class TestMinitestUnitTestCase < Minitest::Test
     assert_equal expected, sample_test_case.runnable_methods
   end
 
-  def test_i_suck_and_my_tests_are_order_dependent_bang_sets_test_order_alpha
+  def test_tests_are_order_dependent_bang_sets_test_order_alpha
     @assertion_count = 0
 
-    shitty_test_case = Class.new Minitest::Test
+    intergration_test = Class.new Minitest::Test
 
-    shitty_test_case.i_suck_and_my_tests_are_order_dependent!
+    intergration_test.tests_are_order_dependent!
 
-    assert_equal :alpha, shitty_test_case.test_order
+    assert_equal :alpha, intergration_test.test_order
   end
 
-  def test_i_suck_and_my_tests_are_order_dependent_bang_does_not_warn
+  def test_tests_are_order_dependent_bang_does_not_warn
     @assertion_count = 0
 
-    shitty_test_case = Class.new Minitest::Test
+    intergration_test = Class.new Minitest::Test
 
-    def shitty_test_case.test_order ; :lol end
+    def intergration_test.test_order ; :lol end
 
     assert_silent do
-      shitty_test_case.i_suck_and_my_tests_are_order_dependent!
+      intergration_test.tests_are_order_dependent!
     end
+  end
+
+  def test_i_suck_and_my_tests_are_order_dependent_alias
+    @assertion_count = 0
+
+    intergration_test = Class.new Minitest::Test
+
+    intergration_test.i_suck_and_my_tests_are_order_dependent!
+
+    assert_equal :alpha, intergration_test.test_order
   end
 
   def util_assert_triggered expected, klass = Minitest::Assertion


### PR DESCRIPTION
`i_suck_and_my_tests_are_order_dependent` is still aliased and usable.

This is a sort-of followup to the immature issue #398.

In several projects I need my tests to run in a specific order (e.g. integration tests).

Yes, #398 was inappropriate, but I like the idea being less offensive and more polite to users.

Opinions?
