### PR TITLE
Use new name

### DIFF
--- a/lib/minitest/parallel.rb
+++ b/lib/minitest/parallel.rb
@@ -31,7 +31,7 @@ module Minitest
 
       module ClassMethods
         def run_one_method klass, method_name, reporter
-          MiniTest.parallel_executor << [klass, method_name, reporter]
+          Minitest.parallel_executor << [klass, method_name, reporter]
         end
         def test_order; :parallel; end
       end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -266,7 +266,7 @@ class TestMinitestMock < Minitest::Test
   end
 
   def test_mock_block_is_passed_function_block
-    mock = MiniTest::Mock.new
+    mock = Minitest::Mock.new
     block = proc { 'bar' }
     mock.expect :foo, nil do |arg, &blk|
       arg == 'foo' &&


### PR DESCRIPTION
Found a couple of inconsistencies with the `Minitest` vs `MiniTest` naming. This makes everything consistent under the `Minitest` name. Thank you!
