### PR TITLE
Use Markdown for README

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,7 +1,7 @@
 .autotest
 History.txt
 Manifest.txt
-README.txt
+README.md
 Rakefile
 design_rationale.rb
 lib/hoe/minitest.rb

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-= minitest/{unit,spec,mock,benchmark}
+# minitest/{unit,spec,mock,benchmark}
 
 home :: https://github.com/seattlerb/minitest
 rdoc :: http://docs.seattlerb.org/minitest
 vim  :: https://github.com/sunaku/vim-ruby-minitest
 emacs:: https://github.com/arthurnn/minitest-emacs
 
-== DESCRIPTION:
+## DESCRIPTION:
 
 minitest provides a complete suite of testing facilities supporting
 TDD, BDD, mocking, and benchmarking.
@@ -61,7 +61,7 @@ classes, modules, inheritance, methods. This means you only have to
 learn ruby to use minitest and all of your regular OO practices like
 extract-method refactorings still apply.
 
-== FEATURES/PROBLEMS:
+## FEATURES/PROBLEMS:
 
 * minitest/autorun - the easy and explicit way to run all your tests.
 * minitest/unit - a very fast, simple, and clean test system.
@@ -71,168 +71,168 @@ extract-method refactorings still apply.
 * minitest/pride - show your pride in testing!
 * Incredibly small and fast runner, but no bells and whistles.
 
-== RATIONALE:
+## RATIONALE:
 
 See design_rationale.rb to see how specs and tests work in minitest.
 
-== SYNOPSIS:
+## SYNOPSIS:
 
 Given that you'd like to test the following class:
 
-  class Meme
-    def i_can_has_cheezburger?
-      "OHAI!"
+    class Meme
+      def i_can_has_cheezburger?
+        "OHAI!"
+      end
+
+      def will_it_blend?
+        "YES!"
+      end
     end
 
-    def will_it_blend?
-      "YES!"
-    end
-  end
-
-=== Unit tests
+### Unit tests
 
 Define your tests as methods beginning with `test_`.
 
-  require "minitest/autorun"
+    require "minitest/autorun"
 
-  class TestMeme < Minitest::Test
-    def setup
-      @meme = Meme.new
-    end
+    class TestMeme < Minitest::Test
+      def setup
+        @meme = Meme.new
+      end
 
-    def test_that_kitty_can_eat
-      assert_equal "OHAI!", @meme.i_can_has_cheezburger?
-    end
+      def test_that_kitty_can_eat
+        assert_equal "OHAI!", @meme.i_can_has_cheezburger?
+      end
 
-    def test_that_it_will_not_blend
-      refute_match /^no/i, @meme.will_it_blend?
-    end
+      def test_that_it_will_not_blend
+        refute_match /^no/i, @meme.will_it_blend?
+      end
 
-    def test_that_will_be_skipped
-      skip "test this later"
-    end
-  end
-
-=== Specs
-
-  require "minitest/autorun"
-
-  describe Meme do
-    before do
-      @meme = Meme.new
-    end
-
-    describe "when asked about cheeseburgers" do
-      it "must respond positively" do
-        @meme.i_can_has_cheezburger?.must_equal "OHAI!"
+      def test_that_will_be_skipped
+        skip "test this later"
       end
     end
 
-    describe "when asked about blending possibilities" do
-      it "won't say no" do
-        @meme.will_it_blend?.wont_match /^no/i
+### Specs
+
+    require "minitest/autorun"
+
+    describe Meme do
+      before do
+        @meme = Meme.new
+      end
+
+      describe "when asked about cheeseburgers" do
+        it "must respond positively" do
+          @meme.i_can_has_cheezburger?.must_equal "OHAI!"
+        end
+      end
+
+      describe "when asked about blending possibilities" do
+        it "won't say no" do
+          @meme.will_it_blend?.wont_match /^no/i
+        end
       end
     end
-  end
 
 For matchers support check out:
 
 https://github.com/zenspider/minitest-matchers
 
-=== Benchmarks
+### Benchmarks
 
 Add benchmarks to your tests.
 
-  # optionally run benchmarks, good for CI-only work!
-  require "minitest/benchmark" if ENV["BENCH"]
+    # optionally run benchmarks, good for CI-only work!
+    require "minitest/benchmark" if ENV["BENCH"]
 
-  class TestMeme < Minitest::Benchmark
-    # Override self.bench_range or default range is [1, 10, 100, 1_000, 10_000]
-    def bench_my_algorithm
-      assert_performance_linear 0.9999 do |n| # n is a range value
-        @obj.my_algorithm(n)
+    class TestMeme < Minitest::Benchmark
+      # Override self.bench_range or default range is [1, 10, 100, 1_000, 10_000]
+      def bench_my_algorithm
+        assert_performance_linear 0.9999 do |n| # n is a range value
+          @obj.my_algorithm(n)
+        end
       end
     end
-  end
 
 Or add them to your specs. If you make benchmarks optional, you'll
 need to wrap your benchmarks in a conditional since the methods won't
 be defined. In minitest 5, the describe name needs to match
 /Bench(mark)?$/.
 
-  describe "Meme Benchmark" do
-    if ENV["BENCH"] then
-      bench_performance_linear "my_algorithm", 0.9999 do |n|
-        100.times do
-          @obj.my_algorithm(n)
+    describe "Meme Benchmark" do
+      if ENV["BENCH"] then
+        bench_performance_linear "my_algorithm", 0.9999 do |n|
+          100.times do
+            @obj.my_algorithm(n)
+          end
         end
       end
     end
-  end
 
 outputs something like:
 
-  # Running benchmarks:
+    # Running benchmarks:
 
-  TestBlah	100	1000	10000
-  bench_my_algorithm	 0.006167	 0.079279	 0.786993
-  bench_other_algorithm	 0.061679	 0.792797	 7.869932
+    TestBlah	100	1000	10000
+    bench_my_algorithm	 0.006167	 0.079279	 0.786993
+    bench_other_algorithm	 0.061679	 0.792797	 7.869932
 
 Output is tab-delimited to make it easy to paste into a spreadsheet.
 
-=== Mocks
+### Mocks
 
-  class MemeAsker
-    def initialize(meme)
-      @meme = meme
+    class MemeAsker
+      def initialize(meme)
+        @meme = meme
+      end
+
+      def ask(question)
+        method = question.tr(" ","_") + "?"
+        @meme.__send__(method)
+      end
     end
 
-    def ask(question)
-      method = question.tr(" ","_") + "?"
-      @meme.__send__(method)
-    end
-  end
+    require "minitest/autorun"
 
-  require "minitest/autorun"
+    describe MemeAsker do
+      before do
+        @meme = Minitest::Mock.new
+        @meme_asker = MemeAsker.new @meme
+      end
 
-  describe MemeAsker do
-    before do
-      @meme = Minitest::Mock.new
-      @meme_asker = MemeAsker.new @meme
-    end
-
-    describe "#ask" do
-      describe "when passed an unpunctuated question" do
-        it "should invoke the appropriate predicate method on the meme" do
-          @meme.expect :will_it_blend?, :return_value
-          @meme_asker.ask "will it blend"
-          @meme.verify
+      describe "#ask" do
+        describe "when passed an unpunctuated question" do
+          it "should invoke the appropriate predicate method on the meme" do
+            @meme.expect :will_it_blend?, :return_value
+            @meme_asker.ask "will it blend"
+            @meme.verify
+          end
         end
       end
     end
-  end
 
-=== Stubs
+### Stubs
 
-  def test_stale_eh
-    obj_under_test = Something.new
+    def test_stale_eh
+      obj_under_test = Something.new
 
-    refute obj_under_test.stale?
+      refute obj_under_test.stale?
 
-    Time.stub :now, Time.at(0) do   # stub goes away once the block is done
-      assert obj_under_test.stale?
+      Time.stub :now, Time.at(0) do   # stub goes away once the block is done
+        assert obj_under_test.stale?
+      end
     end
-  end
 
 A note on stubbing: In order to stub a method, the method must
 actually exist prior to stubbing. Use a singleton method to create a
 new non-existing method:
 
-  def obj_under_test.fake_method
-    ...
-  end
+    def obj_under_test.fake_method
+      ...
+    end
 
-== Writing Extensions
+## Writing Extensions
 
 To define a plugin, add a file named minitest/XXX_plugin.rb to your
 project/gem. Minitest will find and require that file using
@@ -258,7 +258,7 @@ bogus example:
       end
     end
 
-=== Adding custom reporters
+### Adding custom reporters
 
 Minitest uses composite reporter to output test results using multiple
 reporter instances. You can add new reporters to the composite during
@@ -297,9 +297,9 @@ Using our example above, here is how we might implement MyCI:
       end
     end
 
-== FAQ
+## FAQ
 
-=== How to test SimpleDelegates?
+### How to test SimpleDelegates?
 
 The following implementation and test:
 
@@ -345,7 +345,7 @@ or you can extend the Worker class (within the test file!), like:
       include ::Minitest::Expectations
     end
 
-=== How to share code across test classes?
+### How to share code across test classes?
 
 Use a module. That's exactly what they're for:
 
@@ -369,7 +369,7 @@ you want to extend your test using setup/teardown via a module, just
 make sure you ALWAYS call super. before/after automatically call super
 for you, so make sure you don't do it twice.
 
-== Prominent Projects using Minitest:
+## Prominent Projects using Minitest:
 
 * arel
 * journey
@@ -380,8 +380,9 @@ for you, so make sure you don't do it twice.
 * rdoc
 * ...and of course, everything from seattle.rb...
 
-== Known Extensions:
+## Known Extensions:
 
+```
 capybara_minitest_spec      :: Bridge between Capybara RSpec matchers and MiniTest::Spec expectations (e.g. page.must_have_content("Title")).
 minispec-metadata           :: Metadata for describe/it blocks
                                (e.g. `it "requires JS driver", js: true do`)
@@ -443,8 +444,9 @@ minitest_tu_shim            :: minitest_tu_shim bridges between test/unit and mi
 mongoid-minitest            :: MiniTest matchers for Mongoid.
 pry-rescue                  :: A pry plugin w/ minitest support. See pry-rescue/minitest.rb.
 rspec2minitest              :: Easily translate any RSpec matchers to MiniTest assertions and expectations.
+```
 
-== Unknown Extensions:
+## Unknown Extensions:
 
 Authors... Please send me a pull request with a description of your minitest extension.
 
@@ -468,22 +470,22 @@ Authors... Please send me a pull request with a description of your minitest ext
 * mongoid-minitest
 * spork-minitest
 
-== REQUIREMENTS:
+## REQUIREMENTS:
 
 * Ruby 1.8, maybe even 1.6 or lower. No magic is involved.
 
-== INSTALL:
+## INSTALL:
 
-  sudo gem install minitest
+    sudo gem install minitest
 
 On 1.9, you already have it. To get newer candy you can still install
 the gem, and then requiring "minitest/autorun" should automatically
 pull it in. If not, you'll need to do it yourself:
 
-  gem "minitest"     # ensures you"re using the gem, and not the built-in MT
-  require "minitest/autorun"
+    gem "minitest"     # ensures you"re using the gem, and not the built-in MT
+    require "minitest/autorun"
 
-  # ... usual testing stuffs ...
+    # ... usual testing stuffs ...
 
 DO NOTE: There is a serious problem with the way that ruby 1.9/2.0
 packages their own gems. They install a gem specification file, but
@@ -492,7 +494,7 @@ Gem.find_files and many other things (gem which, gem contents, etc).
 
 Just install minitest as a gem for real and you'll be happier.
 
-== LICENSE:
+## LICENSE:
 
 (The MIT License)
 


### PR DESCRIPTION
I'm not the only one confused why this is an issue, the majority of the projects I've seen use Markdown. As Minitest ships with Ruby as the default testing tool it's especially important to have documentation looking its best. No doubt this is why there are dozens of requests for the presentation of the documentation to be improved.

Even the [generated documentation](http://rubydoc.info/gems/minitest/5.3.0/frames) linked to from the [gem page](http://rubygems.org/gems/minitest) suffers from all kinds of formatting problems. It's just sort of dumped in there as-is, and without formatting the code examples are really mangled, indendation collapsed. The other [official documentation](http://docs.seattlerb.org/minitest/) seems to be handled properly because RDoc understands how to deal with that format of file.

The reasons for rejection seem to be that Markdown is not supported by `hoe` and `rdoc`.

Markdown _is_ supported, as `Hoe#initialize` has the following:

```
self.history_file ||= Dir.glob("History.{txt,md}").first
self.readme_file  ||= Dir.glob("README.{txt,md}").first
```

The major difference between `.md` and `.rd` is the use of `#` vs. `=` to denote headers, and this is even accounted for in the `intuit_values` method:

```
s =~ /^[=#]/ ? s.strip.downcase.chomp(':').split.last : s.strip
```

I was able to use Markdown in [a forked project](https://github.com/tadman/minitest) if I did the following steps:
- Renamed `README.txt` to `README.md`
- Converted the formatting, `=` to `#`.
- Adjusted code indentation to start at four spaces instead of two.
- Updated `Manifest.txt` with `README.md`.

All of the `rake` operations seem to work, including the documentation generator, where the `index.html` looked fine. The [Yard generated documentation](http://rubydoc.info/github/tadman/minitest/master/frames) is as significantly improved, no longer mangled.

If there's anything else here that needs to be fixed, I'll do my best to fix it, yet as far as I can tell there's no obstacle to Markdown support.
