### PR TITLE
Formatted readme as markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-= minitest/{unit,spec,mock,benchmark}
+# minitest/{unit,spec,mock,benchmark}
 
-home :: https://github.com/seattlerb/minitest
-rdoc :: http://docs.seattlerb.org/minitest
-vim  :: https://github.com/sunaku/vim-ruby-minitest
-emacs:: https://github.com/arthurnn/minitest-emacs
+- [home](https://github.com/seattlerb/minitest)
+- [rdoc](http://docs.seattlerb.org/minitest)
+- [vim](https://github.com/sunaku/vim-ruby-minitest)
+- [emacs](https://github.com/arthurnn/minitest-emacs)
 
-== DESCRIPTION:
+## Description
 
 minitest provides a complete suite of testing facilities supporting
 TDD, BDD, mocking, and benchmarking.
 
-    "I had a class with Jim Weirich on testing last week and we were
-     allowed to choose our testing frameworks. Kirk Haines and I were
-     paired up and we cracked open the code for a few test
-     frameworks...
+>    "I had a class with Jim Weirich on testing last week and we were
+>    allowed to choose our testing frameworks. Kirk Haines and I were
+>    paired up and we cracked open the code for a few test
+>    frameworks...
 
-     I MUST say that minitest is *very* readable / understandable
-     compared to the 'other two' options we looked at. Nicely done and
-     thank you for helping us keep our mental sanity."
+>    I MUST say that minitest is *very* readable / understandable
+>    compared to the 'other two' options we looked at. Nicely done and
+>    thank you for helping us keep our mental sanity."
 
-    -- Wayne E. Seguin
+>    -- Wayne E. Seguin
 
 minitest/unit is a small and incredibly fast unit testing framework.
 It provides a rich set of assertions to make your tests clean and
@@ -45,23 +45,23 @@ implementors that need a minimal set of methods to bootstrap a working
 test suite. For example, there is no magic involved for test-case
 discovery.
 
-    "Again, I can't praise enough the idea of a testing/specing
-     framework that I can actually read in full in one sitting!"
+>    "Again, I can't praise enough the idea of a testing/specing
+>    framework that I can actually read in full in one sitting!"
 
-    -- Piotr Szotkowski
+>    -- Piotr Szotkowski
 
 Comparing to rspec:
 
-    rspec is a testing DSL. minitest is ruby.
+>   rspec is a testing DSL. minitest is ruby.
 
-    -- Adam Hawkins, "Bow Before MiniTest"
+>   -- Adam Hawkins, "Bow Before MiniTest"
 
 minitest doesn't reinvent anything that ruby already provides, like:
 classes, modules, inheritance, methods. This means you only have to
 learn ruby to use minitest and all of your regular OO practices like
 extract-method refactorings still apply.
 
-== FEATURES/PROBLEMS:
+## Features/Problems:
 
 * minitest/autorun - the easy and explicit way to run all your tests.
 * minitest/unit - a very fast, simple, and clean test system.
@@ -71,168 +71,168 @@ extract-method refactorings still apply.
 * minitest/pride - show your pride in testing!
 * Incredibly small and fast runner, but no bells and whistles.
 
-== RATIONALE:
+## Rationale:
 
 See design_rationale.rb to see how specs and tests work in minitest.
 
-== SYNOPSIS:
+## Synopsis:
 
 Given that you'd like to test the following class:
 
-  class Meme
-    def i_can_has_cheezburger?
-      "OHAI!"
+    class Meme
+      def i_can_has_cheezburger?
+        "OHAI!"
+      end
+
+      def will_it_blend?
+        "YES!"
+      end
     end
 
-    def will_it_blend?
-      "YES!"
-    end
-  end
-
-=== Unit tests
+### Unit tests
 
 Define your tests as methods beginning with `test_`.
 
-  require "minitest/autorun"
+    require "minitest/autorun"
 
-  class TestMeme < Minitest::Test
-    def setup
-      @meme = Meme.new
-    end
+    class TestMeme < Minitest::Test
+      def setup
+        @meme = Meme.new
+      end
 
-    def test_that_kitty_can_eat
-      assert_equal "OHAI!", @meme.i_can_has_cheezburger?
-    end
+      def test_that_kitty_can_eat
+        assert_equal "OHAI!", @meme.i_can_has_cheezburger?
+      end
 
-    def test_that_it_will_not_blend
-      refute_match /^no/i, @meme.will_it_blend?
-    end
+      def test_that_it_will_not_blend
+        refute_match /^no/i, @meme.will_it_blend?
+      end
 
-    def test_that_will_be_skipped
-      skip "test this later"
-    end
-  end
-
-=== Specs
-
-  require "minitest/autorun"
-
-  describe Meme do
-    before do
-      @meme = Meme.new
-    end
-
-    describe "when asked about cheeseburgers" do
-      it "must respond positively" do
-        @meme.i_can_has_cheezburger?.must_equal "OHAI!"
+      def test_that_will_be_skipped
+        skip "test this later"
       end
     end
 
-    describe "when asked about blending possibilities" do
-      it "won't say no" do
-        @meme.will_it_blend?.wont_match /^no/i
+### Specs
+
+    require "minitest/autorun"
+
+    describe Meme do
+      before do
+        @meme = Meme.new
+      end
+
+      describe "when asked about cheeseburgers" do
+        it "must respond positively" do
+          @meme.i_can_has_cheezburger?.must_equal "OHAI!"
+        end
+      end
+
+      describe "when asked about blending possibilities" do
+        it "won't say no" do
+          @meme.will_it_blend?.wont_match /^no/i
+        end
       end
     end
-  end
 
 For matchers support check out:
 
 https://github.com/zenspider/minitest-matchers
 
-=== Benchmarks
+### Benchmarks
 
 Add benchmarks to your tests.
 
-  # optionally run benchmarks, good for CI-only work!
-  require "minitest/benchmark" if ENV["BENCH"]
+    # optionally run benchmarks, good for CI-only work!
+    require "minitest/benchmark" if ENV["BENCH"]
 
-  class TestMeme < Minitest::Benchmark
-    # Override self.bench_range or default range is [1, 10, 100, 1_000, 10_000]
-    def bench_my_algorithm
-      assert_performance_linear 0.9999 do |n| # n is a range value
-        @obj.my_algorithm(n)
+    class TestMeme < Minitest::Benchmark
+      # Override self.bench_range or default range is [1, 10, 100, 1_000, 10_000]
+      def bench_my_algorithm
+        assert_performance_linear 0.9999 do |n| # n is a range value
+          @obj.my_algorithm(n)
+        end
       end
     end
-  end
 
 Or add them to your specs. If you make benchmarks optional, you'll
 need to wrap your benchmarks in a conditional since the methods won't
 be defined. In minitest 5, the describe name needs to match
 /Bench(mark)?$/.
 
-  describe "Meme Benchmark" do
-    if ENV["BENCH"] then
-      bench_performance_linear "my_algorithm", 0.9999 do |n|
-        100.times do
-          @obj.my_algorithm(n)
+    describe "Meme Benchmark" do
+      if ENV["BENCH"] then
+        bench_performance_linear "my_algorithm", 0.9999 do |n|
+          100.times do
+            @obj.my_algorithm(n)
+          end
         end
       end
     end
-  end
 
 outputs something like:
 
-  # Running benchmarks:
+    # Running benchmarks:
 
-  TestBlah	100	1000	10000
-  bench_my_algorithm	 0.006167	 0.079279	 0.786993
-  bench_other_algorithm	 0.061679	 0.792797	 7.869932
+    TestBlah	100	1000	10000
+    bench_my_algorithm	 0.006167	 0.079279	 0.786993
+    bench_other_algorithm	 0.061679	 0.792797	 7.869932
 
 Output is tab-delimited to make it easy to paste into a spreadsheet.
 
-=== Mocks
+### Mocks
 
-  class MemeAsker
-    def initialize(meme)
-      @meme = meme
+    class MemeAsker
+      def initialize(meme)
+        @meme = meme
+      end
+
+      def ask(question)
+        method = question.tr(" ","_") + "?"
+        @meme.__send__(method)
+      end
     end
 
-    def ask(question)
-      method = question.tr(" ","_") + "?"
-      @meme.__send__(method)
-    end
-  end
+    require "minitest/autorun"
 
-  require "minitest/autorun"
+    describe MemeAsker do
+      before do
+        @meme = Minitest::Mock.new
+        @meme_asker = MemeAsker.new @meme
+      end
 
-  describe MemeAsker do
-    before do
-      @meme = Minitest::Mock.new
-      @meme_asker = MemeAsker.new @meme
-    end
-
-    describe "#ask" do
-      describe "when passed an unpunctuated question" do
-        it "should invoke the appropriate predicate method on the meme" do
-          @meme.expect :will_it_blend?, :return_value
-          @meme_asker.ask "will it blend"
-          @meme.verify
+      describe "#ask" do
+        describe "when passed an unpunctuated question" do
+          it "should invoke the appropriate predicate method on the meme" do
+            @meme.expect :will_it_blend?, :return_value
+            @meme_asker.ask "will it blend"
+            @meme.verify
+          end
         end
       end
     end
-  end
 
-=== Stubs
+### Stubs
 
-  def test_stale_eh
-    obj_under_test = Something.new
+    def test_stale_eh
+      obj_under_test = Something.new
 
-    refute obj_under_test.stale?
+      refute obj_under_test.stale?
 
-    Time.stub :now, Time.at(0) do   # stub goes away once the block is done
-      assert obj_under_test.stale?
+      Time.stub :now, Time.at(0) do   # stub goes away once the block is done
+        assert obj_under_test.stale?
+      end
     end
-  end
 
 A note on stubbing: In order to stub a method, the method must
 actually exist prior to stubbing. Use a singleton method to create a
 new non-existing method:
 
-  def obj_under_test.fake_method
-    ...
-  end
+    def obj_under_test.fake_method
+      ...
+    end
 
-== Writing Extensions
+## Writing Extensions
 
 To define a plugin, add a file named minitest/XXX_plugin.rb to your
 project/gem. Minitest will find and require that file using
@@ -258,20 +258,21 @@ bogus example:
       end
     end
 
-=== Adding custom reporters
+
+### Adding custom reporters
 
 Minitest uses composite reporter to output test results using multiple
 reporter instances. You can add new reporters to the composite during
-the init_plugins phase. As we saw in +plugin_bonus_init+ above, you
-simply add your reporter instance to the composite via +<<+.
+the `init_plugins` phase. As we saw in `plugin_bonus_init` above, you
+simply add your reporter instance to the composite via `<<`.
 
-+AbstractReporter+ defines the API for reporters. You may subclass it
+`AbstractReporter` defines the API for reporters. You may subclass it
 and override any method you want to achieve your desired behavior.
 
-start   :: Called when the run has started.
-record  :: Called for each result, passed or otherwise.
-report  :: Called at the end of the run.
-passed? :: Called to see if you detected any problems.
+* `start`   - Called when the run has started.
+* `record`  - Called for each result, passed or otherwise.
+* `report`  - Called at the end of the run.
+* `passed?` - Called to see if you detected any problems.
 
 Using our example above, here is how we might implement MyCI:
 
@@ -297,9 +298,9 @@ Using our example above, here is how we might implement MyCI:
       end
     end
 
-== FAQ
+## FAQ
 
-=== How to test SimpleDelegates?
+### How to test SimpleDelegates?
 
 The following implementation and test:
 
@@ -345,7 +346,7 @@ or you can extend the Worker class (within the test file!), like:
       include ::Minitest::Expectations
     end
 
-=== How to share code across test classes?
+### How to share code across test classes?
 
 Use a module. That's exactly what they're for:
 
@@ -369,7 +370,7 @@ you want to extend your test using setup/teardown via a module, just
 make sure you ALWAYS call super. before/after automatically call super
 for you, so make sure you don't do it twice.
 
-== Prominent Projects using Minitest:
+## Prominent Projects using Minitest:
 
 * arel
 * journey
@@ -380,7 +381,9 @@ for you, so make sure you don't do it twice.
 * rdoc
 * ...and of course, everything from seattle.rb...
 
-== Known Extensions:
+## Known Extensions:
+
+```
 
 capybara_minitest_spec      :: Bridge between Capybara RSpec matchers and
                                Minitest::Spec expectations (e.g.
@@ -468,7 +471,9 @@ pry-rescue                  :: A pry plugin w/ minitest support. See
 rspec2minitest              :: Easily translate any RSpec matchers to Minitest
                                assertions and expectations.
 
-== Unknown Extensions:
+```
+
+## Unknown Extensions:
 
 Authors... Please send me a pull request with a description of your minitest extension.
 
@@ -492,22 +497,22 @@ Authors... Please send me a pull request with a description of your minitest ext
 * mongoid-minitest
 * spork-minitest
 
-== REQUIREMENTS:
+## Requirements:
 
 * Ruby 1.8, maybe even 1.6 or lower. No magic is involved.
 
-== INSTALL:
+## Install:
 
-  sudo gem install minitest
+    sudo gem install minitest
 
 On 1.9, you already have it. To get newer candy you can still install
 the gem, and then requiring "minitest/autorun" should automatically
 pull it in. If not, you'll need to do it yourself:
 
-  gem "minitest"     # ensures you"re using the gem, and not the built-in MT
-  require "minitest/autorun"
+    gem "minitest"     # ensures you"re using the gem, and not the built-in MT
+    require "minitest/autorun"
 
-  # ... usual testing stuffs ...
+    # ... usual testing stuffs ...
 
 DO NOTE: There is a serious problem with the way that ruby 1.9/2.0
 packages their own gems. They install a gem specification file, but
@@ -516,7 +521,7 @@ Gem.find_files and many other things (gem which, gem contents, etc).
 
 Just install minitest as a gem for real and you'll be happier.
 
-== LICENSE:
+## LICENSE:
 
 (The MIT License)
 


### PR DESCRIPTION
Hi and thanks for maintaining a great tool!

I've found the plaintext readme is hard to read, so I reformatted it in Markdown. The diff is gigantic but I haven't changed any of the content whatsoever. I've also refrained from using the fancier features of Markdown to keep it readable for those who do not view it on Github or through a parser.

I think that this makes it a lot more pleasant to read on Github without making it less pleasant for those who don't.

**Changes:**
- replaced `=`-headers with `#`-headers
- put quotes after angle brackets `>` 
- bumped code-blocks in a step to be picked up as code (still 2 space indentation within the code blocks though)
- replaced `+` notation with markdown code-ticks
- put a couple of things in lists to keep them underneath each other
- put the "Known Extensions" within code-fences to not screw up the formatting, it could be made as a table as well but it's a little trickier. If you're planning to accept this PR and want it as a table just let me know.

Cheers!
