### PR TITLE
Provide second person forms assert_raise, assert_throw and assert_include

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -186,13 +186,14 @@ module Minitest
     ##
     # Fails unless +collection+ includes +obj+.
 
-    def assert_includes collection, obj, msg = nil
+    def assert_include collection, obj, msg = nil
       msg = message(msg) {
         "Expected #{mu_pp(collection)} to include #{mu_pp(obj)}"
       }
       assert_respond_to collection, :include?
       assert collection.include?(obj), msg
     end
+    alias_method :assert_includes, :assert_include
 
     ##
     # Fails unless +obj+ is an instance of +cls+.
@@ -286,7 +287,7 @@ module Minitest
     # Fails unless the block raises one of +exp+. Returns the
     # exception matched so you can check the message, attributes, etc.
 
-    def assert_raises *exp
+    def assert_raise *exp
       msg = "#{exp.pop}.\n" if String === exp.last
 
       begin
@@ -314,6 +315,7 @@ module Minitest
 
       flunk "#{msg}#{mu_pp(exp)} expected but nothing was raised."
     end
+    alias_method :assert_raises, :assert_raise
 
     ##
     # Fails unless +obj+ responds to +meth+.
@@ -362,7 +364,7 @@ module Minitest
     ##
     # Fails unless the block throws +sym+
 
-    def assert_throws sym, msg = nil
+    def assert_throw sym, msg = nil
       default = "Expected #{mu_pp(sym)} to have been thrown"
       caught = true
       catch(sym) do
@@ -380,6 +382,7 @@ module Minitest
 
       assert caught, message(msg) { default }
     end
+    alias_method :assert_throws, :assert_throw
 
     ##
     # Captures $stdout and $stderr into strings:
@@ -550,13 +553,14 @@ module Minitest
     ##
     # Fails if +collection+ includes +obj+.
 
-    def refute_includes collection, obj, msg = nil
+    def refute_include collection, obj, msg = nil
       msg = message(msg) {
         "Expected #{mu_pp(collection)} to not include #{mu_pp(obj)}"
       }
       assert_respond_to collection, :include?
       refute collection.include?(obj), msg
     end
+    alias_method :refute_includes, :refute_include
 
     ##
     # Fails if +obj+ is an instance of +cls+.

--- a/lib/minitest/expectations.rb
+++ b/lib/minitest/expectations.rb
@@ -54,13 +54,13 @@ module Minitest::Expectations
   infect_an_assertion :assert_in_epsilon, :must_be_within_epsilon
 
   ##
-  # See Minitest::Assertions#assert_includes
+  # See Minitest::Assertions#assert_include
   #
   #    collection.must_include obj
   #
   # :method: must_include
 
-  infect_an_assertion :assert_includes, :must_include, :reverse
+  infect_an_assertion :assert_include, :must_include, :reverse
 
   ##
   # See Minitest::Assertions#assert_instance_of
@@ -121,13 +121,13 @@ module Minitest::Expectations
   infect_an_assertion :assert_output, :must_output
 
   ##
-  # See Minitest::Assertions#assert_raises
+  # See Minitest::Assertions#assert_raise
   #
   #    proc { ... }.must_raise exception
   #
   # :method: must_raise
 
-  infect_an_assertion :assert_raises, :must_raise
+  infect_an_assertion :assert_raise, :must_raise
 
   ##
   # See Minitest::Assertions#assert_respond_to
@@ -157,13 +157,13 @@ module Minitest::Expectations
   infect_an_assertion :assert_silent, :must_be_silent
 
   ##
-  # See Minitest::Assertions#assert_throws
+  # See Minitest::Assertions#assert_throw
   #
   #    proc { ... }.must_throw sym
   #
   # :method: must_throw
 
-  infect_an_assertion :assert_throws, :must_throw
+  infect_an_assertion :assert_throw, :must_throw
 
   ##
   # See Minitest::Assertions#refute_empty
@@ -204,13 +204,13 @@ module Minitest::Expectations
   infect_an_assertion :refute_in_epsilon, :wont_be_within_epsilon
 
   ##
-  # See Minitest::Assertions#refute_includes
+  # See Minitest::Assertions#refute_include
   #
   #    collection.wont_include obj
   #
   # :method: wont_include
 
-  infect_an_assertion :refute_includes, :wont_include, :reverse
+  infect_an_assertion :refute_include, :wont_include, :reverse
 
   ##
   # See Minitest::Assertions#refute_instance_of

--- a/test/minitest/test_minitest_unit.rb
+++ b/test/minitest/test_minitest_unit.rb
@@ -1401,7 +1401,7 @@ class TestMinitestUnitTestCase < Minitest::Test
     # These don't have corresponding refutes _on purpose_. They're
     # useless and will never be added, so don't bother.
     ignores = %w[assert_output assert_raises assert_send
-                 assert_silent assert_throws]
+                 assert_silent assert_throws assert_throw]
 
     # These are test/unit methods. I'm not actually sure why they're still here
     ignores += %w[assert_no_match assert_not_equal assert_not_nil


### PR DESCRIPTION
This PR provides `assert_raise`, `assert_throw` and `{assert|refute}_include` while aliasing existing `assert_raises`, etc.

This:
- provides consistent api with other minitest assertions like `assert_send`, `assert_respond_to`, `assert_output`, `assert_match` and `assert_equal` and thus reduces cognitive load.
- makes api consistent with Matz's established naming convention for Ruby, see for example http://stackoverflow.com/questions/5280556/why-does-ruby-use-respond-to-instead-of-responds-to

Thanks
