### PR TITLE
Amend assert documentation to match code.

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -6,7 +6,7 @@ module Minitest
   # printed if the assertion fails.
   #
   # Protocol: Nearly everything here boils up to +assert+, which
-  # expects to be able to increment an instance variable named
+  # expects to be able to increment an instance accessor named
   # +assertions+. This is not provided by Assertions and must be
   # provided by the thing including Assertions. See Minitest::Runnable
   # for an example.


### PR DESCRIPTION
Surfaced in https://github.com/rspec/rspec-core/issues/1354

Alternatively, you could change the code back to an instance variable, which would be nicer for RSpec.
