### PR TITLE
Join spec methods with underscore

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -204,7 +204,7 @@ class Minitest::Spec < Minitest::Test
       @specs ||= 0
       @specs += 1
 
-      name = "test_%04d_%s" % [ @specs, desc ]
+      name = "test_%04d_%s" % [ @specs, desc.gsub(" ", "_") ]
 
       define_method name, &block
 

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -763,7 +763,7 @@ class TestMeta < MetaMetaMetaTestCase
       z = describe "second thingy" do end
     end
 
-    test_methods = ["test_0001_top level it", "test_0002_не латинские буквы-и-спецсимволы&いった α, β, γ, δ, ε hello!!! world"].sort
+    test_methods = ["test_0001_top_level_it", "test_0002_не_латинские_буквы-и-спецсимволы&いった_α,_β,_γ,_δ,_ε_hello!!!_world"].sort
 
     assert_equal test_methods, [x1, x2]
     assert_equal test_methods,


### PR DESCRIPTION
It makes sense, to me at least, if the test and spec methods follow the same naming convention.

Thoughts?
