### PR TITLE
Run test suites in random order:

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -138,7 +138,7 @@ module Minitest
   # loaded if a Runnable calls parallelize_me!.
 
   def self.__run reporter, options
-    suites = Runnable.runnables
+    suites = Runnable.runnables.shuffle
     parallel, serial = suites.partition { |s| s.test_order == :parallel }
 
     # If we run the parallel tests before the serial tests, the parallel tests


### PR DESCRIPTION
Randomization helps detect order-dependent tests (aka. crappy tests). Test
_methods_ have been randomized for a long time; this commit randomizes the
order test _suites_ are run in as well.

Example:

```
class TestFoo < Minitest::Test; end
class TestBar < Minitest::Test; end
```

Before: TestFoo would always run before TestBar. Tests within TestFoo/TestBar
would be randomized, but the suite themselves were called in a specific order.

After: TestBar might (or might) not run before TestFoo. It's currently not
possible to disable suite randomization, but if you have order-dependent test
you really ought to place them in the same class and use
i_suck_and_my_tests_are_order_dependent!

(This pull request implements #425)
