### PR TITLE
Use additional_desc to determine spec type

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -60,7 +60,7 @@ module Kernel # :nodoc:
     sclas = stack.last || if Class === self && is_a?(Minitest::Spec::DSL) then
                             self
                           else
-                            Minitest::Spec.spec_type desc
+                            Minitest::Spec.spec_type desc, additional_desc
                           end
 
     cls = sclas.create name, desc
@@ -132,10 +132,14 @@ class Minitest::Spec < Minitest::Test
     #
     #     spec_type("BlahController") # => Minitest::Spec::Rails
 
-    def spec_type desc
+    def spec_type desc, additional_desc = nil
       TYPES.find { |matcher, klass|
         if matcher.respond_to? :call then
-          matcher.call desc
+          if additional_desc then
+            matcher.call desc, additional_desc
+          else
+            matcher.call desc
+          end
         else
           matcher === desc.to_s
         end

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -659,10 +659,14 @@ class TestMeta < MetaMetaMetaTestCase
     p = lambda do |x| true end
     Minitest::Spec.register_spec_type TestMeta, &p
 
+    q = lambda do |x, y| true end
+    Minitest::Spec.register_spec_type TestMeta, &q
+
     keys = Minitest::Spec::TYPES.map(&:first)
 
     assert_includes keys, /woot/
     assert_includes keys, p
+    assert_includes keys, q
   ensure
     Minitest::Spec::TYPES.replace original_types
   end
@@ -674,9 +678,17 @@ class TestMeta < MetaMetaMetaTestCase
     Minitest::Spec.register_spec_type MiniSpecB do |desc|
       desc.superclass == ExampleA
     end
+    Minitest::Spec.register_spec_type MiniSpecB do |desc, addl|
+      addl == :mini_spec_b
+    end
+    Minitest::Spec.register_spec_type MiniSpecB do |desc, addl|
+      addl.is_a?(Hash) && addl[:mini_spec_b]
+    end
 
     assert_equal MiniSpecA, Minitest::Spec.spec_type(ExampleA)
     assert_equal MiniSpecB, Minitest::Spec.spec_type(ExampleB)
+    assert_equal MiniSpecB, Minitest::Spec.spec_type("Not ExampleB Constant", :mini_spec_b)
+    assert_equal MiniSpecB, Minitest::Spec.spec_type("Not ExampleB Constant", {:mini_spec_b => true})
   ensure
     Minitest::Spec::TYPES.replace original_types
   end


### PR DESCRIPTION
We can determine spec_type by `desc`, but not `additional_desc`.

This change should be 100% backwards compatible. It will allow minitest-rails to register spec types by the additional spec. So folks can create tests using the spec DSL like so:

``` ruby
class ActionDispatch::IntegrationTest
  register_spec_type(self) do |_, additional_desc|
    addl_desc == :integration
  end
end

describe "Some User Action", :integration do
  it "does some things" do
    self.class.ancestors.must_include ActionDispatch::IntegrationTest
  end
end
```
