### PR TITLE
Add minitest-bang to known extensions on README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -422,6 +422,8 @@ minispec-metadata           :: Metadata for describe/it blocks
 minitest-ansi               :: Colorize minitest output with ANSI colors.
 minitest-around             :: Around block for minitest. An alternative to
                                setup/teardown dance.
+minitest-bang               :: Adds support for RSpec-style let! to immediately
+                               invoke let statements before each test.
 minitest-capistrano         :: Assertions and expectations for testing
                                Capistrano recipes.
 minitest-capybara           :: Capybara matchers support for minitest unit and


### PR DESCRIPTION
I recently created an extension gem, minitest-bang that adds `let!` that operates similarly to RSpec's method of the same name. We're successfully using it in the test suite for a very large production app. A lot of members on our team were more familiar with RSpec and this one silly little thing was the thing we missed the most.
