### PR TITLE
"warning: (...) interpreted as grouped expression"

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -43,7 +43,7 @@ module Minitest
 
   def self.autorun
     at_exit {
-      next if $! and not ($!.kind_of? SystemExit and $!.success?)
+      next if $! and !($!.kind_of? SystemExit and $!.success?)
 
       exit_code = nil
 


### PR DESCRIPTION
minitest spits out tons of warnings when run with -w for RUBYOPT.
