### PR TITLE
only test `msg` if the assertion fails

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -122,9 +122,9 @@ module Minitest
     # Fails unless +test+ is truthy.
 
     def assert test, msg = nil
-      msg ||= "Failed assertion, no message given."
       self.assertions += 1
       unless test then
+        msg ||= "Failed assertion, no message given."
         msg = msg.call if Proc === msg
         raise Minitest::Assertion, msg
       end


### PR DESCRIPTION
We don't need to allocate a string or test the `msg` variable unless the
test fails.  This speeds up successful assertions.

Here is my test:

``` ruby
require 'minitest'
require 'benchmark/ips'

tc = Class.new(Minitest::Test) {
  def my_assert test, msg = nil
    self.assertions += 1
    unless test then
      msg ||= "Failed assertion, no message given."
      msg = msg.call if Proc === msg
      raise Minitest::Assertion, msg
    end
    true
  end
}.new 'omg'

Benchmark.ips do |x|
  x.report('assert true') { tc.assert true }
  x.report('my_assert true') { tc.my_assert true }
end
```

Results (before this patch is applied):

```
[aaron@higgins minitest (master)]$ ruby -Ilib test.rb
Calculating -------------------------------------
         assert true     25360 i/100ms
      my_assert true     30573 i/100ms
-------------------------------------------------
         assert true   887451.1 (±7.0%) i/s -    4412640 in   5.001759s
      my_assert true  1300576.7 (±5.6%) i/s -    6481476 in   5.000332s
```
