### PR TITLE
Add assertions assert_raises_with_message

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -338,24 +338,12 @@ module Minitest
     # passed.
 
     def assert_raises_with_message exp, exp_msg, msg = nil
-      begin
+      e = assert_raises exp do
         yield
-      rescue exp => e
-        return assert_equal exp_msg, e.message, msg
-      rescue Minitest::Skip, Minitest::Assertion
-        # don't count assertion
-        raise
-      rescue SignalException, SystemExit
-        raise
-      rescue Exception => e
-        flunk proc {
-          exception_details(e, "#{msg}#{mu_pp(exp)} exception expected, not")
-        }
       end
 
-      flunk "#{msg}#{mu_pp(exp)} expected but nothing was raised."
+      assert_match Regexp.new(exp_msg), e.message, msg
     end
-
 
     ##
     # Fails unless +obj+ responds to +meth+.

--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -331,6 +331,33 @@ module Minitest
     end
 
     ##
+    # Fails unless the block raises +exp+ and +exp+'s message is equal to +msg+.
+    #
+    # +exp+ takes an optional message on the end to help explain
+    # failures and defaults to StandardError if no exception class is
+    # passed.
+
+    def assert_raises_with_message exp, exp_msg, msg = nil
+      begin
+        yield
+      rescue exp => e
+        return assert_equal exp_msg, e.message, msg
+      rescue Minitest::Skip, Minitest::Assertion
+        # don't count assertion
+        raise
+      rescue SignalException, SystemExit
+        raise
+      rescue Exception => e
+        flunk proc {
+          exception_details(e, "#{msg}#{mu_pp(exp)} exception expected, not")
+        }
+      end
+
+      flunk "#{msg}#{mu_pp(exp)} expected but nothing was raised."
+    end
+
+
+    ##
     # Fails unless +obj+ responds to +meth+.
 
     def assert_respond_to obj, meth, msg = nil

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1356,6 +1356,34 @@ class TestMinitestUnitTestCase < Minitest::Test
     end
   end
 
+  def test_assert_raises_with_message_wrong_message
+    e = assert_raises Minitest::Assertion do
+      @tc.assert_raises_with_message StandardError, "test" do
+        raise "txt"
+      end
+    end
+
+    expected = "Expected: \"test\"\n  Actual: \"txt\""
+    assert_equal expected, e.message
+  end
+
+  def test_assert_raises_with_message_wrong_message
+    e = assert_raises Minitest::Assertion do
+      @tc.assert_raises_with_message StandardError, "test" do
+        # do not raise
+      end
+    end
+
+    expected = "StandardError expected but nothing was raised."
+    assert_equal expected, e.message
+  end
+
+  def test_assert_raises_with_message
+    @tc.assert_raises_with_message StandardError, "test" do
+      raise "test"
+    end
+  end
+
   def test_assert_raises_subclass_triggered
     e = assert_raises Minitest::Assertion do
       @tc.assert_raises SomeError do

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1357,17 +1357,18 @@ class TestMinitestUnitTestCase < Minitest::Test
   end
 
   def test_assert_raises_with_message_wrong_message
+    @assertion_count += 2
     e = assert_raises Minitest::Assertion do
       @tc.assert_raises_with_message StandardError, "test" do
         raise "txt"
       end
     end
 
-    expected = "Expected: \"test\"\n  Actual: \"txt\""
+    expected = "Expected /test/ to match \"txt\"."
     assert_equal expected, e.message
   end
 
-  def test_assert_raises_with_message_wrong_message
+  def test_assert_raises_with_message_dont_raise
     e = assert_raises Minitest::Assertion do
       @tc.assert_raises_with_message StandardError, "test" do
         # do not raise
@@ -1379,8 +1380,16 @@ class TestMinitestUnitTestCase < Minitest::Test
   end
 
   def test_assert_raises_with_message
+    @assertion_count += 2
     @tc.assert_raises_with_message StandardError, "test" do
       raise "test"
+    end
+  end
+
+  def test_assert_raises_with_regexp
+    @assertion_count += 2
+    @tc.assert_raises_with_message StandardError, /test/ do
+      raise "this is testability"
     end
   end
 
@@ -1563,7 +1572,8 @@ class TestMinitestUnitTestCase < Minitest::Test
     # These don't have corresponding refutes _on purpose_. They're
     # useless and will never be added, so don't bother.
     ignores = %w[assert_output assert_raises assert_send
-                 assert_silent assert_throws assert_mock]
+                 assert_silent assert_throws assert_mock
+                 assert_raises_with_message]
 
     # These are test/unit methods. I'm not actually sure why they're still here
     ignores += %w[assert_no_match assert_not_equal assert_not_nil


### PR DESCRIPTION
#530

`assert_raises_with_message`:
- handles exceptions exactly the same way `assert_raises` does. (And can be dried up if you think it's necessary)
- `assert_equals` in the exception's message

What do you think about the complexity of it?
