### PR TITLE
Expose options

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -40,6 +40,11 @@ module Minitest
   mc.send :attr_accessor, :extensions
 
   ##
+  # The options used for this test run.
+
+  mc.send :attr_accessor, :options
+
+  ##
   # The signal to use for dumping information to STDERR. Defaults to "INFO".
 
   mc.send :attr_accessor, :info_signal
@@ -226,7 +231,7 @@ module Minitest
       s =~ /[\s|&<>$()]/ ? s.inspect : s
     }.join " "
 
-    options
+    self.options = options
   end
 
   def self.filter_backtrace bt # :nodoc:


### PR DESCRIPTION
This PR exposes the minitest `options` var.

Our team leverages minitest with a custom library to make live HTTP requests against our APIs. Particularly, we want access to the generated `seed` value so we can easily identify specific test runs in logs/splunk (our API test library would pass this value along in each request during the test run).
