### PR TITLE
Make the testopts accessible in your tests.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -456,11 +456,13 @@ in order to require minitest, you must first add the <tt>gem 'minitest'</tt>
 to your Gemfile and run +bundle+. Once it's installed, you should be
 able to require minitest and run your tests.
 
-=== How can I access the testopts (for example the seed value) in my tests?
+=== How can I access the minitest options (for example the seed value) in my tests?
 
 If you like to use for example the generated or given seed value in your tests
-you can get the minitest options now with +Minitest.testopts+ and the seed value
-by calling +Minitest.testopts[:seed]+ from everywhere.
+you can get the minitest options now with +Minitest.options+ from everywhere.
+This is usefull to feed the random seed generator before testing something with random input,
+by just calling +srand Minitest.options[:seed]+ for example in a test setup.
+    
 
 == Prominent Projects using Minitest:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -456,6 +456,12 @@ in order to require minitest, you must first add the <tt>gem 'minitest'</tt>
 to your Gemfile and run +bundle+. Once it's installed, you should be
 able to require minitest and run your tests.
 
+=== How can I access the testopts (for example the seed value) in my tests?
+
+If you like to use for example the generated or given seed value in your tests
+you can get the minitest options now with +Minitest.testopts+ and the seed value
+by calling +Minitest.testopts[:seed]+ from everywhere.
+
 == Prominent Projects using Minitest:
 
 * arel

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -47,6 +47,10 @@ module Minitest
   self.info_signal = "INFO"
 
   ##
+  # Access the testopts for example to use the seed value in your tests.
+  mc.send :attr_accessor, :testopts
+
+  ##
   # Registers Minitest to run at process exit
 
   def self.autorun
@@ -121,6 +125,7 @@ module Minitest
     self.load_plugins unless args.delete("--no-plugins") || ENV["MT_NO_PLUGINS"]
 
     options = process_args args
+    self.testopts = options
 
     reporter = CompositeReporter.new
     reporter << SummaryReporter.new(options[:io], options)

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -47,8 +47,8 @@ module Minitest
   self.info_signal = "INFO"
 
   ##
-  # Access the testopts for example to use the seed value in your tests.
-  mc.send :attr_accessor, :testopts
+  # Access the minitest options for example to use the seed value in your tests.
+  mc.send :attr_accessor, :options
 
   ##
   # Registers Minitest to run at process exit
@@ -125,7 +125,7 @@ module Minitest
     self.load_plugins unless args.delete("--no-plugins") || ENV["MT_NO_PLUGINS"]
 
     options = process_args args
-    self.testopts = options
+    self.options = options
 
     reporter = CompositeReporter.new
     reporter << SummaryReporter.new(options[:io], options)


### PR DESCRIPTION
Hello,

I would like to have the options available to use in my tests.
Especially the seed value is very interesting for me.
I would like to make some tests use different, random but reproducable input everytime the tests run to cover more test cases.
The seed value is good to support that kind of stuff, but I have to access it somehow in my test cases.
By exposing the options as attr_accessor I can use it.

Thanks!