### PR TITLE
Create explicit LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Ryan Davis, seattle.rb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.rdoc
+++ b/README.rdoc
@@ -636,4 +636,4 @@ Just install minitest as a gem for real and you'll be happier.
 
 == LICENSE:
 
-Licensed under the [MIT-License](LICENSE).
+Licensed under the [MIT-License](./LICENSE).

--- a/README.rdoc
+++ b/README.rdoc
@@ -636,4 +636,4 @@ Just install minitest as a gem for real and you'll be happier.
 
 == LICENSE:
 
-Licensed under the [MIT-License](./LICENSE).
+Licensed under the MIT-License. See <tt>LICENSE</tt> in this repo.

--- a/README.rdoc
+++ b/README.rdoc
@@ -636,25 +636,4 @@ Just install minitest as a gem for real and you'll be happier.
 
 == LICENSE:
 
-(The MIT License)
-
-Copyright (c) Ryan Davis, seattle.rb
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Licensed under the [MIT-License](LICENSE).


### PR DESCRIPTION
GitHub now supports displaying the license directly on the repository overview if the license file is crafted properly: https://github.com/blog/2252-license-now-displayed-on-repository-overview

This PR adds a license file and moves the MIT license out of the README and into its own file. The README still references the license and points to its location.

This will improve compatibility with license tracking software like the [papers](https://github.com/newrelic/papers) gem.