### PR TITLE
add benchmark tests

### DIFF
--- a/test/minitest/test_minitest_benchmark.rb
+++ b/test/minitest/test_minitest_benchmark.rb
@@ -118,6 +118,32 @@ class TestMinitestBenchmark < Minitest::Test
     assert_fit :power, x, y, 0.96, 3.119e-5, 0.8959
   end
 
+  def test_sigma
+    bench = Minitest::Benchmark.new :blah
+    assert_equal bench.sigma([1,2,3]), 6
+    assert_equal bench.sigma([1,2,3]) { |n| n**2 }, 14
+  end
+
+  def test_fit_error
+    bench = Minitest::Benchmark.new :blah
+    assert_equal bench.fit_error([[1, 1], [2, 2], [3, 3]]) { |x| x }, 1.0
+    assert_in_delta bench.fit_error([[1, 1], [2, 2], [3, 4]]) { |x| x }, 0.785
+  end
+
+  def test_fit_linear_x2
+    bench = Minitest::Benchmark.new :blah
+    xs = [1, 10, 100, 1000]
+    _a, _b, rr = bench.fit_linear(xs, xs.map { |x| x**2 }), :<, 0.99
+    assert_operator rr, :<, 0.99
+  end
+
+  def test_fit_linear_x3
+    bench = Minitest::Benchmark.new :blah
+    xs = [1, 10, 100, 1000]
+    _a, _b, rr = bench.fit_linear(xs, xs.map { |x| x**3 })
+    assert_operator rr, :<, 0.99
+  end
+
   def assert_fit msg, x, y, fit, exp_a, exp_b
     bench = Minitest::Benchmark.new :blah
 

--- a/test/minitest/test_minitest_benchmark.rb
+++ b/test/minitest/test_minitest_benchmark.rb
@@ -144,6 +144,28 @@ class TestMinitestBenchmark < Minitest::Test
     assert_operator rr, :<, 0.99
   end
 
+  def test_fit_constant_beyond_linear
+    bench = Minitest::Benchmark.new :blah
+    # This is actual data from a Minitest::Benchmark run (testing Tree#push)
+    # It sure looks steeper than linear slope 1.
+    # Look at y go from .05 to .26 as x goes from 1000 to 2000
+    xs = [10, 100, 1000, 2000]
+    ys = [0.000092, 0.000618, 0.050752, 0.258891]
+
+    # I don't know how to call #assert_performance_constant on static data
+    # i.e. without doing timing
+    # Here is what assert_performance_constant tests
+    _a, b, _rr = bench.fit_linear(xs, ys)
+    assert_in_delta 0, b, 0.01
+
+    # The assertion below is intended to be a synthetic version of
+    # #refute_performace_constant
+    refute_in_delta 0, b, 0.01
+
+    # Interestingly, assert_performance_constant succeeds for this data
+    # while assert_performance_linear fails.
+  end
+
   def assert_fit msg, x, y, fit, exp_a, exp_b
     bench = Minitest::Benchmark.new :blah
 


### PR DESCRIPTION
- test_sigma
- test_fit_error
- test_fit_linear_x2 (fails, rr for fit_linear(x2) is over 0.99)
- test_fit_linear_x3 (fails, rr for fit_linear(x3) is over 0.99)

Per discussion on IRC.  Some background:

I have been playing with minitest's fit methods in https://github.com/rickhull/compsci/blob/master/lib/compsci/fit.rb

These tests in this PR originate from that effort.  `test_sigma` and `test_fit_error` because why not, and also per #717 where the comments for `Benchmark#sigma` show an incorrect example.

Separately, I discovered that the r^2 (`rr` or `r2`) value from `fit_linear` is not that useful for distinguishing linear data from x^2 or even x^3.  `test_fit_linear_x2` and `test_fit_linear_x3` fail when I think we really want them to succeed.  See #719 for more details.