### PR TITLE
Only unescape real newlines for diff

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -105,12 +105,9 @@ module Minitest
       expect = mu_pp_for_diff exp
       butwas = mu_pp_for_diff act
 
-      e1, e2 = expect.include?("\n"), expect.include?("\\n")
-      b1, b2 = butwas.include?("\n"), butwas.include?("\\n")
-
       need_to_diff =
-        (e1 ^ e2                  ||
-         b1 ^ b2                  ||
+        (expect.include?("\n")    ||
+         butwas.include?("\n")    ||
          expect.size > 30         ||
          butwas.size > 30         ||
          expect == butwas)        &&
@@ -152,21 +149,7 @@ module Minitest
     def mu_pp_for_diff obj
       str = mu_pp obj
 
-      # both '\n' & '\\n' (_after_ mu_pp (aka inspect))
-      single = !!str.match(/(?<!\\|^)\\n/)
-      double = !!str.match(/(?<=\\|^)\\n/)
-
-      process =
-        if single ^ double then
-          if single then
-            lambda { |s| s == "\\n"   ? "\n"    : s } # unescape
-          else
-            lambda { |s| s == "\\\\n" ? "\\n\n" : s } # unescape a bit, add nls
-          end
-        else
-          :itself                                     # leave it alone
-        end
-
+      process = lambda { |s| s == "\\n" ? "\n" : s } # unescape real newlines
       str.
         gsub(/\\?\\n/, &process).
         gsub(/:0x[a-fA-F0-9]{4,}/m, ":0xXXXXXX") # anonymize hex values

--- a/test/minitest/test_minitest_assertions.rb
+++ b/test/minitest/test_minitest_assertions.rb
@@ -303,15 +303,6 @@ class TestMinitestAssertions < Minitest::Test
   end
 
   def test_assert_equal_string_bug791
-    exp = <<-'EOF'.gsub(/^ {10}/, "") # note single quotes
-          --- expected
-          +++ actual
-          @@ -1,2 +1 @@
-          -"\\n
-          -"
-          +"\\\"
-        EOF
-
     exp = "Expected: \"\\\\n\"\n  Actual: \"\\\\\""
     assert_triggered exp do
       @tc.assert_equal "\\n", "\\"
@@ -322,10 +313,10 @@ class TestMinitestAssertions < Minitest::Test
     msg = <<-EOM.gsub(/^ {10}/, "")
           --- expected
           +++ actual
-          @@ -1,2 +1 @@
-          -\"A\\n
-          -B\"
-          +\"A\\n\\\\nB\"
+          @@ -1 +1,2 @@
+          -\"A\\\\nB\"
+          +\"A
+          +\\\\nB\"
           EOM
 
     assert_triggered msg do
@@ -378,10 +369,10 @@ class TestMinitestAssertions < Minitest::Test
     msg = <<-'EOM'.gsub(/^ {10}/, "") # NOTE single quotes on heredoc
           --- expected
           +++ actual
-          @@ -1,2 +1,2 @@
+          @@ -1,2 +1 @@
           -"hello
-          +"hello\n
-           world"
+          -world"
+          +"hello\\nworld"
           EOM
 
     assert_triggered msg do
@@ -1282,9 +1273,11 @@ class TestMinitestAssertionHelpers < Minitest::Test
     msg = <<-'EOM'.gsub(/^ {10}/, "") # NOTE single quotes on heredoc
           --- expected
           +++ actual
-          @@ -1 +1 @@
-          -"A\\n\nB"
-          +"A\n\\nB"
+          @@ -1,2 +1,2 @@
+          -"A\\n
+          -B"
+          +"A
+          +\\nB"
           EOM
 
     exp = "A\\n\nB"
@@ -1370,7 +1363,7 @@ class TestMinitestAssertionHelpers < Minitest::Test
 
   def test_mu_pp_for_diff_str_bad_encoding_both
     str = "\666A\\n\nB".force_encoding Encoding::UTF_8
-    exp = "# encoding: UTF-8\n#    valid: false\n\"\\xB6A\\\\n\\nB\""
+    exp = "# encoding: UTF-8\n#    valid: false\n\"\\xB6A\\\\n\nB\""
 
     assert_mu_pp_for_diff exp, str, :raw
   end
@@ -1384,34 +1377,34 @@ class TestMinitestAssertionHelpers < Minitest::Test
 
   def test_mu_pp_for_diff_str_encoding_both
     str = "A\\n\nB".b
-    exp = "# encoding: ASCII-8BIT\n#    valid: true\n\"A\\\\n\\nB\""
+    exp = "# encoding: ASCII-8BIT\n#    valid: true\n\"A\\\\n\nB\""
 
     assert_mu_pp_for_diff exp, str, :raw
   end
 
   def test_mu_pp_for_diff_str_nerd
-    assert_mu_pp_for_diff "A\\nB\\\\nC", "A\nB\\nC"
-    assert_mu_pp_for_diff "\\nB\\\\nC",  "\nB\\nC"
-    assert_mu_pp_for_diff "\\nB\\\\n",   "\nB\\n"
-    assert_mu_pp_for_diff "\\n\\\\n",    "\n\\n"
-    assert_mu_pp_for_diff "\\\\n\\n",    "\\n\n"
-    assert_mu_pp_for_diff "\\\\nB\\n",   "\\nB\n"
-    assert_mu_pp_for_diff "\\\\nB\\nC",  "\\nB\nC"
-    assert_mu_pp_for_diff "A\\\\n\\nB",  "A\\n\nB"
-    assert_mu_pp_for_diff "A\\n\\\\nB",  "A\n\\nB"
-    assert_mu_pp_for_diff "\\\\n\\n",    "\\n\n"
-    assert_mu_pp_for_diff "\\n\\\\n",    "\n\\n"
+    assert_mu_pp_for_diff "A\nB\\\\nC", "A\nB\\nC"
+    assert_mu_pp_for_diff "\nB\\\\nC",  "\nB\\nC"
+    assert_mu_pp_for_diff "\nB\\\\n",   "\nB\\n"
+    assert_mu_pp_for_diff "\n\\\\n",    "\n\\n"
+    assert_mu_pp_for_diff "\\\\n\n",    "\\n\n"
+    assert_mu_pp_for_diff "\\\\nB\n",   "\\nB\n"
+    assert_mu_pp_for_diff "\\\\nB\nC",  "\\nB\nC"
+    assert_mu_pp_for_diff "A\\\\n\nB",  "A\\n\nB"
+    assert_mu_pp_for_diff "A\n\\\\nB",  "A\n\\nB"
+    assert_mu_pp_for_diff "\\\\n\n",    "\\n\n"
+    assert_mu_pp_for_diff "\n\\\\n",    "\n\\n"
   end
 
   def test_mu_pp_for_diff_str_normal
     assert_mu_pp_for_diff "",        ""
-    assert_mu_pp_for_diff "A\\n\n",  "A\\n"
-    assert_mu_pp_for_diff "A\\n\nB", "A\\nB"
+    assert_mu_pp_for_diff "A\\\\n",  "A\\n"
+    assert_mu_pp_for_diff "A\\\\nB", "A\\nB"
     assert_mu_pp_for_diff "A\n",     "A\n"
     assert_mu_pp_for_diff "A\nB",    "A\nB"
-    assert_mu_pp_for_diff "\\n\n",   "\\n"
+    assert_mu_pp_for_diff "\\\\n",   "\\n"
     assert_mu_pp_for_diff "\n",      "\n"
-    assert_mu_pp_for_diff "\\n\nA",  "\\nA"
+    assert_mu_pp_for_diff "\\\\nA",  "\\nA"
     assert_mu_pp_for_diff "\nA",     "\nA"
   end
 


### PR DESCRIPTION
This is a fix for #814 that should make the #791 case look good as well. The basic idea is to *only* unescape real newlines, and leave everything else as-is. I think this is the method that gives the least surprising results.