### PR TITLE
wip: moved setup of reporter mutex to the parallel module

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -552,8 +552,6 @@ module Minitest
   # you want. Go nuts.
 
   class AbstractReporter
-    include Mutex_m
-
     ##
     # Starts reporting on the run.
 

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -158,8 +158,8 @@ module Minitest
     # the serial tests won't lock around Reporter#record. Run the serial tests
     # first, so that after they complete, the parallel tests will lock when
     # recording results.
-    serial.map { |suite| suite.run reporter, options } +
-      parallel.map { |suite| suite.run reporter, options }
+    serial.map { |suite| puts suite; suite.run reporter, options } #+
+      # parallel.map { |suite| suite.run reporter, options }
   end
 
   def self.process_args args = [] # :nodoc:

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "optparse"
 require "thread"
 require "mutex_m"

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -2,7 +2,6 @@
 
 require "optparse"
 require "thread"
-require "mutex_m"
 require "minitest/parallel"
 require "stringio"
 
@@ -23,10 +22,6 @@ module Minitest
   # Parallel test executor
 
   mc.send :attr_accessor, :parallel_executor
-
-  warn "DEPRECATED: use MT_CPU instead of N for parallel test runs" if ENV["N"]
-  n_threads = (ENV["MT_CPU"] || ENV["N"] || 2).to_i
-  self.parallel_executor = Parallel::Executor.new n_threads
 
   ##
   # Filter object for backtraces.

--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 
 require "rbconfig"
 require "tempfile"

--- a/lib/minitest/autorun.rb
+++ b/lib/minitest/autorun.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "rubygems"
   gem "minitest"

--- a/lib/minitest/benchmark.rb
+++ b/lib/minitest/benchmark.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "minitest/test"
 require "minitest/spec"
 

--- a/lib/minitest/expectations.rb
+++ b/lib/minitest/expectations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # It's where you hide your "assertions".
 #

--- a/lib/minitest/hell.rb
+++ b/lib/minitest/hell.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "minitest/parallel"
 
 class Minitest::Test

--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MockExpectationError < StandardError; end # :nodoc:
 
 module Minitest # :nodoc:

--- a/lib/minitest/parallel.rb
+++ b/lib/minitest/parallel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Minitest
   module Parallel #:nodoc:
 

--- a/lib/minitest/parallel.rb
+++ b/lib/minitest/parallel.rb
@@ -56,6 +56,11 @@ module Minitest
     module Test # :nodoc:
       def _synchronize; Minitest::Test.io_lock.synchronize { yield }; end # :nodoc:
 
+      def self.included(_klass)
+        super
+        CompositeReporter.__send__(:include, Mutex_m)
+      end
+
       module ClassMethods # :nodoc:
         def run_one_method klass, method_name, reporter
           Minitest.parallel_executor << [klass, method_name, reporter]

--- a/lib/minitest/parallel_plugin.rb
+++ b/lib/minitest/parallel_plugin.rb
@@ -5,5 +5,8 @@ module Minitest
     warn "DEPRECATED: use MT_CPU instead of N for parallel test runs" if ENV["N"]
     n_threads = (ENV["MT_CPU"] || ENV["N"] || 2).to_i
     self.parallel_executor = Parallel::Executor.new n_threads
+
+    require "minitest/ractor_executor"
+    self.parallel_executor = Minitest::RactorExecutor.new n_threads
   end
 end

--- a/lib/minitest/parallel_plugin.rb
+++ b/lib/minitest/parallel_plugin.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Minitest
+  def self.plugin_parallel_init options # :nodoc:
+    warn "DEPRECATED: use MT_CPU instead of N for parallel test runs" if ENV["N"]
+    n_threads = (ENV["MT_CPU"] || ENV["N"] || 2).to_i
+    self.parallel_executor = Parallel::Executor.new n_threads
+  end
+end

--- a/lib/minitest/pride.rb
+++ b/lib/minitest/pride.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "minitest"
 
 Minitest.load_plugins

--- a/lib/minitest/pride_plugin.rb
+++ b/lib/minitest/pride_plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "minitest"
 
 module Minitest

--- a/lib/minitest/ractor_executor.rb
+++ b/lib/minitest/ractor_executor.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Minitest
+  module Parallel
+    module Test # :nodoc:
+      def _synchronize; yield ; end # :nodoc:
+    end
+  end
+
+  class RactorExecutor
+    ##
+    # The size of the pool of workers.
+
+    attr_reader :size, :queue
+
+    def initialize size
+      @size  = size
+      @pool  = nil
+    end
+
+    ##
+    # Add a job to the queue
+
+    def << work; @queue << work; end
+
+    def start
+      init_queue
+      @pool = size.times.map {
+        Ractor.new(@queue) do |queue|
+          while (job = queue.take)
+            klass, method, reporter = job
+            reporter.prerecord klass, method
+            result = Minitest.run_one_method klass, method
+            reporter.record result
+          end
+        end
+      }
+    end
+
+    def shutdown
+      @queue << nil
+      @queue.take
+    end
+
+    private
+
+    def init_queue
+      @queue = Ractor.new(@size) do |pool_size|
+        loop do
+          job = Ractor.receive
+
+          if job.nil?
+            pool_size.times do |i|
+              Ractor.yield nil
+            end
+            break
+          end
+
+          klass, method, reporter = job
+
+          Ractor.yield [klass, method, reporter.dup]
+        end
+      end
+    end
+  end
+end

--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "minitest/test"
 
 class Module # :nodoc:

--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "minitest" unless defined? Minitest::Runnable
 
 module Minitest
@@ -16,7 +18,7 @@ module Minitest
       self.class.name # for Minitest::Reportable
     end
 
-    PASSTHROUGH_EXCEPTIONS = [NoMemoryError, SignalException, SystemExit] # :nodoc:
+    PASSTHROUGH_EXCEPTIONS = [NoMemoryError, SignalException, SystemExit].freeze # :nodoc:
 
     # :stopdoc:
     class << self; attr_accessor :io_lock; end
@@ -84,7 +86,7 @@ module Minitest
       :random
     end
 
-    TEARDOWN_METHODS = %w[ before_teardown teardown after_teardown ] # :nodoc:
+    TEARDOWN_METHODS = %w[ before_teardown teardown after_teardown ].freeze # :nodoc:
 
     ##
     # Runs a single test with setup/teardown hooks.

--- a/lib/minitest/unit.rb
+++ b/lib/minitest/unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # :stopdoc:
 
 unless defined?(Minitest) then


### PR DESCRIPTION
Step towards #872 

Removes report synchronization code into the `parallel` module.