### PR TITLE
Fix error calculations of assert/refute_in_epsilon

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -250,7 +250,7 @@ module Minitest
     # error less than +epsilon+.
 
     def assert_in_epsilon exp, act, epsilon = 0.001, msg = nil
-      assert_in_delta exp, act, [exp.abs, act.abs].min * epsilon, msg
+      assert_in_delta exp, act, exp.abs * epsilon, msg
     end
 
     ##
@@ -668,8 +668,8 @@ module Minitest
     # For comparing Floats.  Fails if +exp+ and +act+ have a relative error
     # less than +epsilon+.
 
-    def refute_in_epsilon a, b, epsilon = 0.001, msg = nil
-      refute_in_delta a, b, a * epsilon, msg
+    def refute_in_epsilon exp, act, epsilon = 0.001, msg = nil
+      refute_in_delta exp, act, exp.abs * epsilon, msg
     end
 
     ##


### PR DESCRIPTION
Relative error is defined with respect to the expected/true value 
https://en.wikipedia.org/wiki/Approximation_error
```ruby
|(exp - act) / exp| <= epsilon
|exp - act| / |exp| <= epsilon
|exp - act| <= epsilon * |exp|
```