### PR TITLE
Support keyword args in mocks and ruby 3

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -169,6 +169,8 @@ module Minitest # :nodoc:
       retval
     end
 
+    ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
+
     def respond_to? sym, include_private = false # :nodoc:
       return true if @expected_calls.key? sym.to_sym
       return true if @delegator && @delegator.respond_to?(sym, include_private)

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -275,6 +275,18 @@ class TestMinitestMock < Minitest::Test
     assert_mock mock
   end
 
+  def test_mock_block_is_passed_keyword_args
+    arg1, arg2, arg3 = :bar, [1, 2, 3], { :a => "a" }
+    mock = Minitest::Mock.new
+    mock.expect :foo, nil do |k1:, k2:, k3:|
+      k1 == arg1 && k2 == arg2 && k3 == arg3
+    end
+
+    mock.foo(k1: arg1, k2: arg2, k3: arg3)
+
+    assert_mock mock
+  end
+
   def test_mock_block_is_passed_function_block
     mock = Minitest::Mock.new
     block = proc { "bar" }


### PR DESCRIPTION
Without changing the API for mock args, falling back to the ruby 2
compatibility mode seems like the easiest way to continue to support
keyword arguments in mocks and ruby 3.