### PR TITLE
fix: make Mock#expect support keyword arguments

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -115,10 +115,10 @@ module Minitest # :nodoc:
       true
     end
 
-    def method_missing sym, *args, &block # :nodoc:
+    def method_missing sym, *args, **kwargs, &block # :nodoc:
       unless @expected_calls.key?(sym) then
         if @delegator && @delegator.respond_to?(sym)
-          return @delegator.public_send(sym, *args, &block)
+          return @delegator.public_send(sym, *args, **kwargs, &block)
         else
           raise NoMethodError, "unmocked method %p, expected one of %p" %
             [sym, @expected_calls.keys.sort_by(&:to_s)]
@@ -129,8 +129,8 @@ module Minitest # :nodoc:
       expected_call = @expected_calls[sym][index]
 
       unless expected_call then
-        raise MockExpectationError, "No more expects available for %p: %p" %
-          [sym, args]
+        raise MockExpectationError, "No more expects available for %p: %p %p" %
+          [sym, args, kwargs]
       end
 
       expected_args, retval, val_block =
@@ -140,8 +140,8 @@ module Minitest # :nodoc:
         # keep "verify" happy
         @actual_calls[sym] << expected_call
 
-        raise MockExpectationError, "mocked method %p failed block w/ %p" %
-          [sym, args] unless val_block.call(*args, &block)
+        raise MockExpectationError, "mocked method %p failed block w/ %p %p" %
+          [sym, args, kwargs] unless val_block.call(*args, **kwargs, &block)
 
         return retval
       end

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -210,7 +210,7 @@ class TestMinitestMock < Minitest::Test
       mock.a
     end
 
-    assert_equal "No more expects available for :a: []", e.message
+    assert_equal "No more expects available for :a: [] {}", e.message
   end
 
   def test_same_method_expects_are_verified_when_all_called
@@ -286,6 +286,13 @@ class TestMinitestMock < Minitest::Test
     assert_mock mock
   end
 
+  def test_mock_forward_keyword_arguments
+    mock = Minitest::Mock.new
+    mock.expect(:foo, nil) { |bar:| bar == 'bar' }
+    mock.foo(bar: 'bar')
+    assert_mock mock
+  end
+
   def test_verify_fails_when_mock_block_returns_false
     mock = Minitest::Mock.new
     mock.expect :foo, nil do
@@ -293,7 +300,7 @@ class TestMinitestMock < Minitest::Test
     end
 
     e = assert_raises(MockExpectationError) { mock.foo }
-    exp = "mocked method :foo failed block w/ []"
+    exp = "mocked method :foo failed block w/ [] {}"
 
     assert_equal exp, e.message
   end


### PR DESCRIPTION
This change aims to fix the bug derived from the following code:

```
m = Minitest::Mock.new
m.expect(:foo, nil) { |bar:| bar == 'bar' }
m.foo(bar: 'bar')
```

Keyword arguments are separated from other arguments since Ruby v3. The current implementation of `Minitest::Mock#method_missing` would print warning message in Ruby v2.7 and no longer work in Ruby v3.

## Bug Reproduce

It shows deprecation warning message In Ruby 2.7.6:

```sh
docker run --rm -i ruby:2.7.6-alpine3.15 sh -c \
  'gem install --silent minitest:5.15.0 && exec "$@"' sh \
  ruby -W:deprecated -rminitest/mock <<EOS
m = Minitest::Mock.new
m.expect(:foo, nil) { |bar:| bar == 'bar' }
m.foo(bar: 'bar')
EOS
```

```
/usr/local/bundle/gems/minitest-5.15.0/lib/minitest/mock.rb:144: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
-e:1: warning: The called method `call' is defined here
```

It raises `ArgumentError` in Ruby 3.1.2:

```sh
docker run --rm -i ruby:3.1.2-alpine3.15 sh -c \
  'gem install --silent minitest:5.15.0 && exec "$@"' sh \
  ruby -W:deprecated -rminitest/mock <<EOS
m = Minitest::Mock.new
m.expect(:foo, nil) { |bar:| bar == 'bar' }
m.foo(bar: 'bar')
EOS
```

```
-e:1:in `block in <main>': missing keyword: :bar (ArgumentError)
        from /usr/local/lib/ruby/gems/3.1.0/gems/minitest-5.15.0/lib/minitest/mock.rb:144:in `method_missing'
        from -e:1:in `<main>'
```

fix #847 