### PR TITLE
docs: add minitest-cc to plugin's list

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -641,6 +641,7 @@ minitest-capistrano         :: Assertions and expectations for testing
                                Capistrano recipes.
 minitest-capybara           :: Capybara matchers support for minitest unit and
                                spec.
+minitest-cc                 :: It provides minimal information about code coverage.
 minitest-chef-handler       :: Run Minitest suites as Chef report handlers
 minitest-ci                 :: CI reporter plugin for Minitest.
 minitest-context            :: Defines contexts for code reuse in Minitest


### PR DESCRIPTION
Hi!
I made a [plugin](https://github.com/a-chacon/minitest-cc) for minitests, 
I do this PR if you want to add it to the README.
Thanks.