### PR TITLE
Use `A` instead of deprecated `TESTOPTS` in `rake test:slow`

### DIFF
--- a/lib/minitest/test_task.rb
+++ b/lib/minitest/test_task.rb
@@ -238,7 +238,7 @@ module Minitest # :nodoc:
 
       desc "Show bottom 25 tests wrt time."
       task "#{name}:slow" do
-        sh ["rake #{name} TESTOPTS=-v",
+        sh ["rake #{name} A=-v",
             "egrep '#test_.* s = .'",
             "sort -n -k2 -t=",
             "tail -25"].join " | "


### PR DESCRIPTION
Using `minitest/test_task` to define my test tasks, `rake test:slow` generates a warning:

```
$ rake test:slow
rake test TESTOPTS=-v | egrep '#test_.* s = .' | sort -n -k2 -t= | tail -25
TESTOPTS is deprecated in Minitest::TestTask. Use A instead
...
```

Using `A`, as recommended by the warning, instead of `TESTOPTS`, should take care of it.
