### PR TITLE
Remove check for `.b` method

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -823,7 +823,7 @@ module Minitest
     end
 
     def to_s # :nodoc:
-      aggregated_results(StringIO.new(binary_string)).string
+      aggregated_results(StringIO.new(''.b)).string
     end
 
     def summary # :nodoc:
@@ -835,14 +835,6 @@ module Minitest
 
       "%d runs, %d assertions, %d failures, %d errors, %d skips%s" %
         [count, assertions, failures, errors, skips, extra]
-    end
-
-    private
-
-    if '<3'.respond_to? :b
-      def binary_string; ''.b; end
-    else
-      def binary_string; ''.force_encoding(Encoding::ASCII_8BIT); end
     end
   end
 


### PR DESCRIPTION
String#b was added in ruby/ruby@a6ec2584527f and shipped with Ruby v2.0.0 and up.  I think we can stop checking for it now