### PR TITLE
Fix race condition causing flaky tests

### DIFF
--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -9,8 +9,6 @@ ensure
 end
 
 class TestMinitestMock < Minitest::Test
-  parallelize_me!
-
   def setup
     @mock = Minitest::Mock.new.expect(:foo, nil)
     @mock.expect(:meaning_of_life, 42)


### PR DESCRIPTION
`TestMinitestMock` used to be parallelized but
it uses `with_kwargs_env()` which changes an environment variable.
Environment variable is global to the process so there are windows
where the variable is deleted by another thread before the test
is done running.

Run the tests serially to fix the occasional failure.

---
We run these tests on CI over at ruby/ruby and sometimes I see failures coming from this issue.