### PR TITLE
Fix kwargs for Mock calls to delegator

### DIFF
--- a/lib/minitest/mock.rb
+++ b/lib/minitest/mock.rb
@@ -150,7 +150,11 @@ module Minitest # :nodoc:
     def method_missing sym, *args, **kwargs, &block # :nodoc:
       unless @expected_calls.key?(sym) then
         if @delegator && @delegator.respond_to?(sym)
-          return @delegator.public_send(sym, *args, **kwargs, &block)
+          if kwargs.empty? then # FIX: drop this after 2.7 dead
+            return @delegator.public_send(sym, *args, &block)
+          else
+            return @delegator.public_send(sym, *args, **kwargs, &block)
+          end
         else
           raise NoMethodError, "unmocked method %p, expected one of %p" %
             [sym, @expected_calls.keys.sort_by(&:to_s)]

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -260,6 +260,15 @@ class TestMinitestMock < Minitest::Test
     assert_equal exp, e.message
   end
 
+  def test_delegator_calls_are_propagated
+    delegator = Object.new
+    mock = Minitest::Mock.new delegator
+
+    refute delegator.nil?
+    refute mock.nil?
+    assert_mock mock
+  end
+
   def test_handles_kwargs_in_error_message
     mock = Minitest::Mock.new
 


### PR DESCRIPTION
Propagate keyword arguments when calling Mock's method missing.

Fixes #932.

Since CI is no longer running against Ruby 2.6 the tests won't show fix.
Here is my local reproduction:

```
$ ruby -v
ruby 2.6.6p146 (2020-03-31 revision 67876) [x86_64-darwin21]
$ rake test
minitest/test_task.rb is now packaged with minitest. If you see
this, you are getting it from hoe instead. If you're NOT able to
upgrade minitest to pick this up, please drop an issue on
seattlerb/hoe and let me know.

Required from /Users/blowmage/.gem/ruby/2.6.6/gems/hoe-3.26.0/lib/hoe/test.rb:86:in `define_test_tasks'
Run options: --seed 41519

# Running:

...................................................................SS.S..SSS....S.....S.....S.....S....................................................................................................................................................................................................................................................................................................................E...........

Finished in 0.247013s, 1696.2670 runs/s, 4991.6401 assertions/s.

  1) Error:
TestMinitestMock#test_delegator_calls_are_propagated:
ArgumentError: wrong number of arguments (given 1, expected 0)
    /Users/blowmage/codez/minitest/test/minitest/test_minitest_mock.rb:268:in `test_delegator_calls_are_propagated'

419 runs, 1233 assertions, 0 failures, 1 errors, 10 skips

You have skipped tests. Run with --verbose for details.
rake aborted!
Command failed with status (1): [/Users/blowmage/.rubies/ruby-2.6.6/bin/rub...]
/Users/blowmage/.gem/ruby/2.6.6/gems/hoe-3.26.0/lib/minitest/test_task.rb:173:in `block in define'
Tasks: TOP => test
(See full trace by running task with --trace)
$ git checkout fix/mock-delegator-kwargs
M	test/minitest/test_minitest_mock.rb
Switched to branch 'fix/mock-delegator-kwargs'
Your branch is up to date with 'blowmage/fix/mock-delegator-kwargs'.
$ rake test
minitest/test_task.rb is now packaged with minitest. If you see
this, you are getting it from hoe instead. If you're NOT able to
upgrade minitest to pick this up, please drop an issue on
seattlerb/hoe and let me know.

Required from /Users/blowmage/.gem/ruby/2.6.6/gems/hoe-3.26.0/lib/hoe/test.rb:86:in `define_test_tasks'
Run options: --seed 25800

# Running:

.............................................................................................................SS.S..SSS....S.....S.....S.....S......................................................................................................................................................................................................................................................................................

Finished in 0.244547s, 1713.3721 runs/s, 5050.1540 assertions/s.

419 runs, 1235 assertions, 0 failures, 0 errors, 10 skips

You have skipped tests. Run with --verbose for details.
```