### PR TITLE
Introduce `assert_pattern` for pattern matching

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -358,6 +358,32 @@ module Minitest
     end
 
     ##
+    # For testing with pattern matching (only supported with Ruby 3.0 and later)
+    #
+    #   # pass
+    #   assert_pattern { [1,2,3] => [Integer, Integer, Integer] }
+    #
+    #   # fail "length mismatch (given 3, expected 1)"
+    #   assert_pattern { [1,2,3] => [Integer] }
+    #
+    # The bare <tt>=></tt> pattern will raise a NoMatchingPatternError on failure, which would
+    # normally be counted as a test error. This assertion rescues NoMatchingPatternError and
+    # generates a test failure. Any other exception will be raised as normal and generate a test
+    # error.
+    #
+    def assert_pattern
+      raise NotImplementedError, "only available in Ruby 3.0+" unless RUBY_VERSION >= "3.0"
+      flunk "assert_pattern requires a block to capture errors." unless block_given?
+
+      begin
+        yield
+        pass
+      rescue NoMatchingPatternError => e
+        flunk(e.message)
+      end
+    end
+
+    ##
     # For testing with predicates. Eg:
     #
     #   assert_predicate str, :empty?
@@ -719,6 +745,30 @@ module Minitest
     def refute_nil obj, msg = nil
       msg = message(msg) { "Expected #{mu_pp(obj)} to not be nil" }
       refute obj.nil?, msg
+    end
+
+    ##
+    # For testing with pattern matching (only supported with Ruby 3.0 and later)
+    #
+    #   # pass
+    #   refute_pattern { [1,2,3] => [String] }
+    #
+    #   # fail "NoMatchingPatternError expected, but nothing was raised."
+    #   refute_pattern { [1,2,3] => [Integer, Integer, Integer] }
+    #
+    # This assertion expects a NoMatchingPatternError exception, and will fail if none is raised. Any
+    # other exceptions will be raised as normal and generate a test error.
+    #
+    def refute_pattern
+      raise NotImplementedError, "only available in Ruby 3.0+" unless RUBY_VERSION >= "3.0"
+      flunk "refute_pattern requires a block to capture errors." unless block_given?
+
+      begin
+        yield
+        flunk("NoMatchingPatternError expected, but nothing was raised.")
+      rescue NoMatchingPatternError
+        pass
+      end
     end
 
     ##

--- a/test/minitest/test_minitest_assertions.rb
+++ b/test/minitest/test_minitest_assertions.rb
@@ -1062,6 +1062,50 @@ class TestMinitestAssertions < Minitest::Test
     end
   end
 
+  def test_assert_pattern
+    if RUBY_VERSION >= "3.0"
+      @tc.assert_pattern do
+        eval "[1,2,3] => [Integer, Integer, Integer]"
+      end
+    else
+      @assertion_count = 0
+
+      assert_raises(NotImplementedError) do
+        @tc.assert_pattern do
+          eval "[1,2,3] => [Integer, Integer, Integer]"
+        end
+      end
+    end
+  end
+
+  def test_assert_pattern_traps_nomatchingpatternerror
+    skip unless RUBY_VERSION >= "3.0"
+
+    assert_triggered(/length mismatch/) do
+      @tc.assert_pattern do
+        eval "[1,2,3] => [Integer, Integer]"
+      end
+    end
+  end
+
+  def test_assert_pattern_raises_other_exceptions
+    skip unless RUBY_VERSION >= "3.0"
+
+    @assertion_count = 0
+
+    assert_raises(RuntimeError) do
+      @tc.assert_pattern do
+        raise "boom"
+      end
+    end
+  end
+
+  def test_assert_pattern_with_no_block
+    assert_triggered "assert_pattern requires a block to capture errors." do
+      @tc.assert_pattern
+    end
+  end
+
   def test_capture_io
     @assertion_count = 0
 
@@ -1311,6 +1355,50 @@ class TestMinitestAssertions < Minitest::Test
   def test_refute_operator_triggered
     assert_triggered "Expected 2 to not be > 1." do
       @tc.refute_operator 2, :>, 1
+    end
+  end
+
+  def test_refute_pattern
+    if RUBY_VERSION >= "3.0"
+      @tc.refute_pattern do
+        eval "[1,2,3] => [Integer, Integer, String]"
+      end
+    else
+      @assertion_count = 0
+
+      assert_raises(NotImplementedError) do
+        @tc.refute_pattern do
+          eval "[1,2,3] => [Integer, Integer, String]"
+        end
+      end
+    end
+  end
+
+  def test_refute_pattern_expects_nomatchingpatternerror
+    skip unless RUBY_VERSION >= "3.0"
+
+    assert_triggered(/NoMatchingPatternError expected, but nothing was raised./) do
+      @tc.refute_pattern do
+        eval "[1,2,3] => [Integer, Integer, Integer]"
+      end
+    end
+  end
+
+  def test_refute_pattern_raises_other_exceptions
+    skip unless RUBY_VERSION >= "3.0"
+
+    @assertion_count = 0
+
+    assert_raises(RuntimeError) do
+      @tc.refute_pattern do
+        raise "boom"
+      end
+    end
+  end
+
+  def test_refute_pattern_with_no_block
+    assert_triggered "refute_pattern requires a block to capture errors." do
+      @tc.refute_pattern
     end
   end
 


### PR DESCRIPTION
## Summary

For testing with pattern matching (only supported with Ruby 3.0 and later)

``` ruby
# pass
assert_pattern { [1,2,3] => [Integer, Integer, Integer] }

# fail "length mismatch (given 3, expected 1)"
assert_pattern { [1,2,3] => [Integer] }
```

## Use case

I can imagine a test case like this exists today:

``` ruby
def test_the_results
  objs = call_that_returns_something
  assert_equal(2, objs.length)
  assert_equal("bob", objs.first.name)
  assert_equal(24, objs.first.age)
  assert_equal("jim", objs.last.name)
  assert_equal(79, objs.last.age)
end
```

I think it's far less verbose and more readable to write:

``` ruby
def test_the_results
  assert_pattern do
    call_that_returns_something => [{name: "bob", age: 24}, {name: "jim", age: 79}] }
  end
end
```

## Alternatives

### `assert` with `<expression> in <pattern>`

One alternative might be to use `assert` along with `<expression> in <pattern>`, like this:

``` ruby
assert(( [1,2,3] in [Integer, Integer, Integer] ))
```

Two notes:

- Yes, we need to use _two_ parens to do this. Yes, that's ugly. See https://bugs.ruby-lang.org/issues/19033 for background.
- No descriptive error message is available, since `<expression> in <pattern>` is a boolean expression. Using `<expression> => <pattern>` raises an exception with very specific descriptions!


### no assertions, just pattern matching

I can imagine an argument being made that this assertion is pretty close to the idea of `refute_raises` (whose nonexistence I mostly agree with), which would lead us to write:

``` ruby
def test_the_results
  call_that_returns_something => [{name: "bob", age: 24}, {name: "jim", age: 79}]
end
```

The `<expression> => <pattern>` expression by itself will raise a `NoMatchingPatternError` on match failure, which is counted as a test _error_. Using this helper will ensure we can easily distinguish between a runtime error and an assertion failure.

I think it's also helpful to visually distinguish between the invocation of `<expression> => <pattern>` to bind a local variable from an invocation that is serving purely as an assertion.
