### PR TITLE
Add ability to match exception messages to `assert_raises` assertion

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -392,8 +392,15 @@ module Minitest
     #   end
     #
     #   assert_equal 'This is really bad', error.message
+    #
+    # Accepts an optional +match+ matcher to test against the raised
+    # exception message. Eg:
+    #
+    #   assert_raises(ArgumentError, match: /bad argument/i) do
+    #     raise ArgumentError, 'Bad argument'
+    #   end
 
-    def assert_raises *exp
+    def assert_raises *exp, match: nil
       flunk "assert_raises requires a block to capture errors." unless
         block_given?
 
@@ -403,7 +410,11 @@ module Minitest
       begin
         yield
       rescue *exp => e
-        pass # count assertion
+        if match
+          assert_match(match, e.message)
+        else
+          pass # count assertion
+        end
         return e
       rescue Minitest::Assertion # incl Skip & UnexpectedError
         # don't count assertion

--- a/test/minitest/test_minitest_assertions.rb
+++ b/test/minitest/test_minitest_assertions.rb
@@ -772,6 +772,24 @@ class TestMinitestAssertions < Minitest::Test
     assert_equal expected, actual
   end
 
+  def test_assert_raises_match
+    @assertion_count = 2
+
+    @tc.assert_raises RuntimeError, match: "blah" do
+      raise "blah"
+    end
+  end
+
+  def test_assert_raises_match_triggered
+    @assertion_count = 2
+
+    assert_triggered 'Expected /nope/ to match "blah".' do
+      @tc.assert_raises RuntimeError, match: /nope/ do
+        raise "blah"
+      end
+    end
+  end
+
   def test_assert_raises_exit
     @tc.assert_raises SystemExit do
       exit 1


### PR DESCRIPTION
Instead of this
```ruby
error = assert_raises(SomeError) do
  do_something
end
assert_equal "Some error message", error.message
```

it is now possible to write this
```ruby
assert_raises(SomeError, match: "Some error message") do # or using a regexp
  do_something
end
```

It is a very popular pattern in tests. I found 373 matches of it in the Rails codebase itself.

This change will also help to avoid a common pitfall when people pass the last argument (as a string/regexp) to `assert_raises` thinking that it will be matched against the error too. There is even a rubocop cop for this - https://github.com/rubocop/rubocop-minitest/blob/master/lib/rubocop/cop/minitest/assert_raises_with_regexp_argument.rb. Personally, I was in this trap several times.

I opened a discussion within the rails community - https://discuss.rubyonrails.org/t/add-assert-raises-with-message-testing-helper/81831 and people find it useful.

I also opened a similar PR in the rails itself - https://github.com/rails/rails/pull/46611, in case this won't be merged. People from the rails core agree on merging this, but we think it is better to upstream to minitest.

There was a similar issue/PR some time ago, supported by many within comments - https://github.com/minitest/minitest/issues/530, but with a different implementation. 