### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
           - head
         include:
           - os: windows-latest
@@ -32,7 +33,7 @@ jobs:
 
     steps:
       - name: repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: load ruby
         uses: ruby/setup-ruby@v1
@@ -58,7 +59,7 @@ jobs:
         || contains(github.event.pull_request.title,  '[skip ci]'))
     steps:
       - name: repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: load ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: install hoe
         run: gem install hoe -N
 
+      - name: install latest minitest # needs to be > 5.16 for minitest/test_task
+        run: gem install minitest -N
+
       - name: rake test
         run: |
           rake test
@@ -69,6 +72,9 @@ jobs:
 
       - name: install hoe
         run: gem install hoe -N
+
+      - name: install latest minitest # needs to be > 5.16 for minitest/test_task
+        run: gem install minitest -N
 
       - name: rake test:isolated
         run: |


### PR DESCRIPTION
Also updates the checkout action versions.

To get older Rubies (pre-Ruby 3.2) to run green, I had to add an install minitest step to ensure that the latest minitest is used, rather than the one bundled with those Rubies.

This all runs green on my fork.