### PR TITLE
Support the new message format of NameError in Ruby 3.3

### DIFF
--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -1083,7 +1083,7 @@ class TestMinitestStub < Minitest::Test
         end
       end
     end
-    exp = "undefined method `write' for nil:NilClass"
+    exp = /undefined method `write' for nil/
     assert_match exp, e.message
   end
 


### PR DESCRIPTION
We are running a trial in Ruby dev branch to change the message format of NameError.

https://bugs.ruby-lang.org/issues/18285

Unfortunately, this change makes a test of minitest fail. Because minitest is bundled with Ruby and tested in `make test-bundled-gems`, I would appreciate it if you could accept the new format in the side of minitest.

Specifically, the following change matters in the test of minitest.

```
old: undefined method `write' for nil:NilClass
new: undefined method `write' for nil
```

Thanks,