### PR TITLE
Fix `parallelize_me!` in `Minitest::Test`

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -365,6 +365,14 @@ module Minitest
       reporter.record Minitest.run_one_method(klass, method_name)
     end
 
+    ##
+    # Defines the order to run tests (:random by default). Override
+    # this or use a convenience method to change it for your tests.
+
+    def self.test_order
+      :random
+    end
+
     def self.with_info_handler reporter, &block # :nodoc:
       handler = lambda do
         unless reporter.passed? then

--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -81,14 +81,6 @@ module Minitest
     end
 
     ##
-    # Defines the order to run tests (:random by default). Override
-    # this or use a convenience method to change it for your tests.
-
-    def self.test_order
-      :random
-    end
-
-    ##
     # Runs a single test with setup/teardown hooks.
 
     def run


### PR DESCRIPTION
When I try to parallelize the whole test with `parallelize_me!` as below, it remains `random`.

```ruby
$ cat minitest.rb
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'minitest'
end

Minitest::Test.class_eval do
  parallelize_me!
end

puts Minitest::Test.test_order
```

```console
$ ruby minitest.rb
random # expected `parallel`, but actual `random`.
```

The reasoning is as follows:

```ruby
$ cat example.rb
class Runnable
  def self.runnable_method
    'runnable_method'
  end
end

class Test < Runnable
  def self.test_method
    'test_method'
  end
end

module ClassMethods
  def runnable_method
    'override'
  end

  def test_method
    'override'
  end
end

Test.extend ClassMethods

puts Test.runnable_method
puts Test.test_method
```

```console
$ ruby example.rb
override
test_method
```

hell.rb has the same problem, it doesn't go `parallel`:
https://github.com/minitest/minitest/blob/v5.18.0/lib/minitest/hell.rb

This PR solves the issue by pulling up `test_order` from `Minitest::Test` to `Minitest::Runnable`. This is useful when running all tests in `parallel` by default. With this fix, the above mentioned issue and hell.rb work in `parallel` (not `random`) as expected.

A current user-side workaround is to call `parallelize_me!` on every class that inherits from `Minitest::Test`, which is inconvenient and doesn't solve the hell.rb problem.