### PR TITLE
Avoid extra string allocations when filtering tests

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -331,19 +331,25 @@ module Minitest
     # reporter to record.
 
     def self.run reporter, options = {}
-      filter = options[:filter] || "/./"
-      filter = Regexp.new $1 if filter.is_a?(String) && filter =~ %r%/(.*)/%
+      filtered_methods = if options[:filter]
+        filter = options[:filter]
+        filter = Regexp.new $1 if filter.is_a?(String) && filter =~ %r%/(.*)/%
 
-      filtered_methods = self.runnable_methods.find_all { |m|
-        filter === m || filter === "#{self}##{m}"
-      }
+        self.runnable_methods.find_all { |m|
+          filter === m || filter === "#{self}##{m}"
+        }
+      else
+        self.runnable_methods
+      end
 
-      exclude = options[:exclude]
-      exclude = Regexp.new $1 if exclude =~ %r%/(.*)/%
+      if options[:exclude]
+        exclude = options[:exclude]
+        exclude = Regexp.new $1 if exclude =~ %r%/(.*)/%
 
-      filtered_methods.delete_if { |m|
-        exclude === m || exclude === "#{self}##{m}"
-      }
+        filtered_methods.delete_if { |m|
+          exclude === m || exclude === "#{self}##{m}"
+        }
+      end
 
       return if filtered_methods.empty?
 


### PR DESCRIPTION
If the user doesn't provide any filters, then we should just avoid filtering anything.  This prevents a couple iterations through the test names and also prevents extra string allocations.

The code below demonstrates the string allocations:

```ruby
require "minitest/autorun"

class MyTest < Minitest::Test
  100.times do |x|
    define_method(:"test_#{x}") do
      assert true
    end
  end

  def self.to_s
    puts "lol"
    super
  end
end
```

Before this patch a "null" filter is always applied in the case a user doesn't pass anything.  Unfortunately this would mean that we're always constructing a string to match against (the class name + method name). The above program will print "lol" when `to_s` is called on the class so you can see the we're converting the class to a string.

This _probably_ isn't a bottleneck in anyone's systems as it's only allocating around 2 strings per method name, but I feel like eliminating these allocations and loops is pretty easy so why not?

I tested this patch against my AArch64 gem repo and saw total allocations for the entire process go from 403176 to 401286 and it has a little over 550 tests.