### PR TITLE
Replace `MiniTest` with `Minitest` in example code

### DIFF
--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -141,7 +141,7 @@ module Minitest
       #     end
       #   end
       #
-      #   class MiniTest::Test
+      #   class Minitest::Test
       #     include MyMinitestPlugin
       #   end
 


### PR DESCRIPTION
This replaces the usage of `MiniTest::Test` in a `LifecycleHooks` documentation comment code example with `Minitest::Test`.

There doesn't appear to be a reason for it to use the old `MiniTest` naming, so it must just have been missed when the switch was made.