### PR TITLE
Optionally allow autorun exit hook to remain active in forked child

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -60,6 +60,9 @@ module Minitest
   cattr_accessor :info_signal
   self.info_signal = "INFO"
 
+  cattr_accessor :allow_fork
+  self.allow_fork = false
+
   ##
   # Registers Minitest to run at process exit
 
@@ -75,7 +78,7 @@ module Minitest
 
       pid = Process.pid
       at_exit {
-        next if Process.pid != pid
+        next if !Minitest.allow_fork && Process.pid != pid
         @@after_run.reverse_each(&:call)
         exit exit_code || false
       }

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1100,6 +1100,16 @@ class TestMinitestUnitTestCase < Minitest::Test
     Process.waitpid(fork { exit 42 })
     assert_equal 42, $?.exitstatus
   end
+
+  def test_autorun_optionally_can_affect_fork_exit_status
+    @assertion_count = 0
+    skip "windows doesn't have fork" unless Process.respond_to?(:fork)
+    Minitest.allow_fork = true
+    Process.waitpid(fork { exit 42 })
+    refute_equal 42, $?.exitstatus
+  ensure
+    Minitest.allow_fork = false
+  end
 end
 
 class TestMinitestGuard < Minitest::Test


### PR DESCRIPTION
My use case is rather bizarre, but I need minitest exit status to be used in the forked child.

This is essentially a flag to disable 9d8064c8