### PR TITLE
Use inline code tags in History file to prevent github from auto-linking text near ENV

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -3,7 +3,7 @@
 * 2 minor enhancements:
 
   * Add metadata lazy accessor to Runnable / Result. (matteeyah)
-  * Only load minitest/unit (aka ancient MiniTest compatibility layer) if ENV["MT_COMPAT"]
+  * Only load minitest/unit (aka ancient MiniTest compatibility layer) <code>if ENV["MT_COMPAT"]</code>
 
 * 1 bug fix:
 
@@ -14,7 +14,7 @@
 * 3 bug fixes:
 
   * Avoid extra string allocations when filtering tests. (tenderlove)
-  * Only mention deprecated ENV['N'] if it is an integer string.
+  * Only mention deprecated <code>ENV['N']</code> if it is an integer string.
   * Push up test_order to Minitest::Runnable to fix minitest/hell. (koic)
 
 === 5.18.0 / 2023-03-04


### PR DESCRIPTION
Github tries to convert text like `ENV["MT_COMPAT"]` into a link which leads nowhere. This PR fixes 2 most recent occurrences of this in the History file.

Before the change:
<img width="720" alt="minitest 2023-08-30 13-57-06" src="https://github.com/minitest/minitest/assets/795/f13a1632-e3fa-42f9-8bf5-0af55466c4cf">

After the change:

<img width="780" alt="minitest 2023-08-30 13-57-41" src="https://github.com/minitest/minitest/assets/795/08881efa-1509-4460-bdc9-7a578da65986">
