### PR TITLE
Add changelog link to README and gem specification

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -3,6 +3,7 @@
 home :: https://github.com/minitest/minitest
 bugs :: https://github.com/minitest/minitest/issues
 rdoc :: https://docs.seattlerb.org/minitest
+clog :: https://github.com/minitest/minitest/blob/master/History.rdoc
 vim  :: https://github.com/sunaku/vim-ruby-minitest
 emacs:: https://github.com/arthurnn/minitest-emacs
 


### PR DESCRIPTION
I noticed that minitest lacks a link to its changelog on its [rubygems.org page](https://rubygems.org/gems/minitest).

This commit adds a changelog link to the README using the special `clog` notation. This URL will automatically be picked up by `hoe`[^1] and be included in the gem specification metadata the next time the gem is
 published.

 [^1]: https://github.com/seattlerb/hoe/blob/bc130abf66c8447254e2ac2e070970e40c0a0158/lib/hoe.rb#L116