### PR TITLE
Removed thread and mutex_m dependencies

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -1,5 +1,4 @@
 require "optparse"
-require "thread"
 require "mutex_m"
 require "minitest/parallel"
 require "stringio"

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -1,5 +1,4 @@
 require "optparse"
-require "mutex_m"
 require "minitest/parallel"
 require "stringio"
 require "etc"
@@ -618,8 +617,6 @@ module Minitest
   # you want. Go nuts.
 
   class AbstractReporter
-    include Mutex_m
-
     ##
     # Starts reporting on the run.
 

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -657,8 +657,8 @@ module Minitest
       true
     end
 
-    def mutex # :nodoc:
-      @mutex
+    def synchronize(&block) # :nodoc:
+      @mutex.synchronize(&block)
     end
   end
 

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -617,6 +617,11 @@ module Minitest
   # you want. Go nuts.
 
   class AbstractReporter
+
+    def initialize # :nodoc:
+      @mutex = Mutex.new
+    end
+
     ##
     # Starts reporting on the run.
 
@@ -650,6 +655,10 @@ module Minitest
 
     def passed?
       true
+    end
+
+    def mutex # :nodoc:
+      @mutex
     end
   end
 

--- a/lib/minitest/parallel.rb
+++ b/lib/minitest/parallel.rb
@@ -29,10 +29,9 @@ module Minitest
             Thread.current.abort_on_exception = true
             while (job = queue.pop)
               klass, method, reporter = job
-              @mutex = Mutex.new
-              @mutex.synchronize { reporter.prerecord klass, method }
+              reporter.mutex.synchronize { reporter.prerecord klass, method }
               result = Minitest.run_one_method klass, method
-              @mutex.synchronize { reporter.record result }
+              reporter.mutex.synchronize { reporter.record result }
             end
           end
         }

--- a/lib/minitest/parallel.rb
+++ b/lib/minitest/parallel.rb
@@ -29,9 +29,9 @@ module Minitest
             Thread.current.abort_on_exception = true
             while (job = queue.pop)
               klass, method, reporter = job
-              reporter.mutex.synchronize { reporter.prerecord klass, method }
+              reporter.synchronize { reporter.prerecord klass, method }
               result = Minitest.run_one_method klass, method
-              reporter.mutex.synchronize { reporter.record result }
+              reporter.synchronize { reporter.record result }
             end
           end
         }

--- a/lib/minitest/parallel.rb
+++ b/lib/minitest/parallel.rb
@@ -29,9 +29,10 @@ module Minitest
             Thread.current.abort_on_exception = true
             while (job = queue.pop)
               klass, method, reporter = job
-              reporter.synchronize { reporter.prerecord klass, method }
+              @mutex = Mutex.new
+              @mutex.synchronize { reporter.prerecord klass, method }
               result = Minitest.run_one_method klass, method
-              reporter.synchronize { reporter.record result }
+              @mutex.synchronize { reporter.record result }
             end
           end
         }

--- a/lib/minitest/test_task.rb
+++ b/lib/minitest/test_task.rb
@@ -288,7 +288,6 @@ end
 
 class Integer # :nodoc:
   def threads_do(jobs) # :nodoc:
-    require "thread"
     q = Work.new jobs
 
     self.times.map {


### PR DESCRIPTION
Ruby core team have plan to extract `mutex_m` from stdlib at Ruby 3.4. After that, `minitest` needs to depend `mutex_m` gem.

I replaced `mutex_m` with simple `Mutex` usage. But I'm not familiar with thread programming. It may be wrong usage.