### PR TITLE
Add missing `include_all` param to `assert_respond_to`

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -449,12 +449,13 @@ module Minitest
 
     ##
     # Fails unless +obj+ responds to +meth+.
+    # include_all defaults to false to match Object#respond_to?
 
-    def assert_respond_to obj, meth, msg = nil
+    def assert_respond_to obj, meth, include_all: false, msg = nil
       msg = message(msg) {
         "Expected #{mu_pp(obj)} (#{obj.class}) to respond to ##{meth}"
       }
-      assert obj.respond_to?(meth), msg
+      assert obj.respond_to?(meth, include_all), msg
     end
 
     ##

--- a/test/minitest/test_minitest_assertions.rb
+++ b/test/minitest/test_minitest_assertions.rb
@@ -41,6 +41,12 @@ class TestMinitestAssertions < Minitest::Test
       self.assertions = 0
       self.failure = nil
     end
+
+    private
+
+    def private_method
+      puts "Hello, I'm private"
+    end
   end
 
   def setup
@@ -928,6 +934,10 @@ class TestMinitestAssertions < Minitest::Test
 
   def test_assert_respond_to
     @tc.assert_respond_to "blah", :empty?
+  end
+
+  def test_assert_respond_to_for_private_method_with_include_all_true
+    @tc.assert_respond_to "blah", :private_method, include_all: true
   end
 
   def test_assert_respond_to_triggered


### PR DESCRIPTION
Add `include_all` param to `assert_respond_to` to mirror `Object#respond_to?`'s parameters.

https://docs.ruby-lang.org/en/3.2/DRb/DRbObject.html#method-i-respond_to-3F

~Am aware this will be a breaking change for anyone with a message specified as people will need to specify `true` or `false` for `include_all` in order to use the `msg` parameter as everything is positional. Alternatively could use some keywords arguments but that's not done much (if at all) in Minitest.~

~Open to suggestions on how best to add `respond_to?`'s missing parameter to `assert_respond_to`.~

Uses a keyword argument for the new `include_all` parameter to allow for backwards compatibility (no breakage).