### PR TITLE
Do not package test files

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -19,11 +19,3 @@ lib/minitest/spec.rb
 lib/minitest/test.rb
 lib/minitest/test_task.rb
 lib/minitest/unit.rb
-test/minitest/metametameta.rb
-test/minitest/test_minitest_assertions.rb
-test/minitest/test_minitest_benchmark.rb
-test/minitest/test_minitest_mock.rb
-test/minitest/test_minitest_reporter.rb
-test/minitest/test_minitest_spec.rb
-test/minitest/test_minitest_test.rb
-test/minitest/test_minitest_test_task.rb


### PR DESCRIPTION
Test files are generally not accessible when installing gems. We can cut them so that we can save some bytes when transferring and storing on all the machines this gem gets installed to.

I did search for a possible PR/issue that was mentioning the above, but could not find anything.

If we go this route, I imagine we could also remove the `.autotest`, `Rakefile` and possibly the `MANIFEST.txt` file.

Please let me know what you think!