### PR TITLE
Filter failure backtrace

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -950,7 +950,7 @@ module Minitest
 
     def location
       last_before_assertion = ""
-      self.backtrace.reverse_each do |s|
+      Minitest.filter_backtrace(self.backtrace).reverse_each do |s|
         break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
         last_before_assertion = s
       end

--- a/test/minitest/metametameta.rb
+++ b/test/minitest/metametameta.rb
@@ -8,11 +8,17 @@ class Minitest::Test
   end
 
   def with_empty_backtrace_filter
+    with_backtrace_filter [] do
+      yield
+    end
+  end
+
+  def with_backtrace_filter bt
     original = Minitest.backtrace_filter
 
     obj = Minitest::BacktraceFilter.new
-    def obj.filter _bt
-      []
+    obj.define_singleton_method(:filter) do |_bt|
+      bt
     end
 
     Minitest::Test.io_lock.synchronize do # try not to trounce in parallel

--- a/test/minitest/test_minitest_reporter.rb
+++ b/test/minitest/test_minitest_reporter.rb
@@ -338,4 +338,16 @@ class TestMinitestReporter < MetaMetaMetaTestCase
 
     assert_equal exp, normalize_output(io.string)
   end
+
+  def test_report_failure_uses_backtrace_filter
+    with_backtrace_filter ["foo.rb:123:in `foo'"] do
+      r.start
+      r.record fail_test
+      r.report
+    end
+
+    exp = "Minitest::Test#woot [foo.rb:123]"
+
+    assert_includes io.string, exp
+  end
 end


### PR DESCRIPTION
This PR ensures test failure backtraces are filtered using the same backtrace filter as errors. This is useful when the backtrace includes lines that aren't helpful for understanding the assertion that has failed. One such use-case is test helpers that are typed using [Sorbet](https://github.com/sorbet/sorbet):

```rb
sig { void }
def assert_something
  assert false
end
```

| Before | After |
| - | - |
| <img width="1402" alt="Screenshot 2023-12-06 at 17 05 32" src="https://github.com/minitest/minitest/assets/770763/43e82fe1-acbd-4e1d-b326-30d1cc615c25" width="480"> | <img width="1402" alt="Screenshot 2023-12-06 at 17 04 18" src="https://github.com/minitest/minitest/assets/770763/93b01267-8056-4b3e-a401-da8eed391a05" width="480"> |

I saw there is already [a PR](https://github.com/minitest/minitest/pull/919) opened with a similar change but it appears to be abandoned (no tests)? I've added a test that the backtrace filter is used when reporting failures, but please let me know if there's anything else needed.

Is there a plausible scenario where filtering the failure backtrace _doesn't_ make sense? I can't think of one at the moment, so hopefully this change is suitable!