### PR TITLE
Allow empty_run! and reporter to display summary for empty runs

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -167,10 +167,10 @@ module Minitest
 
     # might have been removed/replaced during init_plugins:
     summary = reporter.reporters.grep(SummaryReporter).first
-    return empty_run! options if summary && summary.count == 0
 
     reporter.report
 
+    return empty_run! options if summary && summary.count == 0
     reporter.passed?
   end
 


### PR DESCRIPTION
If we make it possible to print both messages, which fixes the rails test suite that are failing even after 5.22.2.

```
Running 0 tests in a single process (parallelization threshold is 50)
Run options: --seed 15821

# Running:



Finished in 0.000369s, 0.0000 runs/s, 0.0000 assertions/s.
0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
```

For example when there are no tests run, we still don't get the default Rails reporter with number of runs, asserts, benchmark, etc.

```
# Running:

Running 0 tests in a single process (parallelization threshold is 50)
Run options: --seed 20717
```

This results in failing test cases, like:

```
Failure:
ApplicationTests::TestRunnerTest#test_system_tests_are_not_run_with_the_default_test_command [test/application/test_runner_test.rb:1193]:
Expected /0\ runs,\ 0\ assertions,\ 0\ failures,\ 0\ errors,\ 0\ skips/ to match "Running 0 tests in a single process (parallelization threshold is 50)\nRun options: --seed 20717\n\n# Running:\n\n".
```

See rails/rails#50978