### PR TITLE
Make the test suite compatible with --enable-frozen-string-literal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
             ruby: ruby
           - os: macos-latest
             ruby: ruby
+          - os: ubuntu-latest
+            ruby: ruby
+            rubyopt: "--enable-frozen-string-literal"
 
     steps:
       - name: repo checkout
@@ -76,5 +79,5 @@ jobs:
 
       - name: rake test:isolated
         run: |
-          rake test:isolated
+          rake test:isolated RUBYOPT="${{ matrix.rubyopt }}"
         timeout-minutes: 3

--- a/test/minitest/metametameta.rb
+++ b/test/minitest/metametameta.rb
@@ -56,7 +56,7 @@ class MetaMetaMetaTestCase < Minitest::Test
   def run_tu_with_fresh_reporter flags = %w[--seed 42]
     options = Minitest.process_args flags
 
-    @output = StringIO.new("".encode('UTF-8'))
+    @output = StringIO.new("".encode(Encoding::UTF_8))
 
     self.reporter = Minitest::CompositeReporter.new
     reporter << Minitest::SummaryReporter.new(@output, options)

--- a/test/minitest/test_minitest_assertions.rb
+++ b/test/minitest/test_minitest_assertions.rb
@@ -379,7 +379,7 @@ class TestMinitestAssertions < Minitest::Test
           EOM
 
     assert_triggered msg do
-      x = "bad-utf8-\xF1.txt".force_encoding "ASCII"
+      x = "bad-utf8-\xF1.txt".dup.force_encoding Encoding::ASCII
       y = x.dup.force_encoding "binary" # TODO: switch to .b when 1.9 dropped
       @tc.assert_equal x, y
     end
@@ -1646,14 +1646,14 @@ class TestMinitestAssertionHelpers < Minitest::Test
   end
 
   def test_mu_pp_for_diff_str_bad_encoding
-    str = "\666".force_encoding Encoding::UTF_8
+    str = "\666".dup.force_encoding Encoding::UTF_8
     exp = "# encoding: UTF-8\n#    valid: false\n\"\\xB6\""
 
     assert_mu_pp_for_diff exp, str, :raw
   end
 
   def test_mu_pp_for_diff_str_bad_encoding_both
-    str = "\666A\\n\nB".force_encoding Encoding::UTF_8
+    str = "\666A\\n\nB".dup.force_encoding Encoding::UTF_8
     exp = "# encoding: UTF-8\n#    valid: false\n\"\\xB6A\\\\n\\nB\""
 
     assert_mu_pp_for_diff exp, str, :raw
@@ -1700,7 +1700,7 @@ class TestMinitestAssertionHelpers < Minitest::Test
   end
 
   def test_mu_pp_str_bad_encoding
-    str = "\666".force_encoding Encoding::UTF_8
+    str = "\666".dup.force_encoding Encoding::UTF_8
     exp = "# encoding: UTF-8\n#    valid: false\n\"\\xB6\""
 
     assert_mu_pp exp, str, :raw

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -686,7 +686,7 @@ class TestMinitestStub < Minitest::Test
   end
 
   def test_stub_yield_self
-    obj = "foo"
+    obj = +"foo"
 
     val = obj.stub :to_s, "bar" do |s|
       s.to_s
@@ -956,7 +956,7 @@ class TestMinitestStub < Minitest::Test
   def test_stub_lambda_block_call_5
     @assertion_count += 1
     rs = nil
-    io = StringIO.new "", "w"
+    io = StringIO.new(+"", "w")
     File.stub5 :open, lambda { |p, m, &blk| blk and blk.call io } do
       File.open "foo.txt", "r" do |f|
         rs = f && f.write("woot")
@@ -971,7 +971,7 @@ class TestMinitestStub < Minitest::Test
 
     @assertion_count += 1
     rs = nil
-    io = StringIO.new "", "w"
+    io = StringIO.new(+"", "w")
     File.stub6 :open, lambda { |p, m, &blk| blk.call io } do
       File.open "foo.txt", "r" do |f|
         rs = f.write("woot")
@@ -984,7 +984,7 @@ class TestMinitestStub < Minitest::Test
   def test_stub_lambda_block_call_args_5
     @assertion_count += 1
     rs = nil
-    io = StringIO.new "", "w"
+    io = StringIO.new(+"", "w")
     File.stub5(:open, lambda { |p, m, &blk| blk and blk.call io }, :WTF?) do
       File.open "foo.txt", "r" do |f|
         rs = f.write("woot")
@@ -999,7 +999,7 @@ class TestMinitestStub < Minitest::Test
 
     @assertion_count += 1
     rs = nil
-    io = StringIO.new "", "w"
+    io = StringIO.new(+"", "w")
     File.stub6(:open, lambda { |p, m, &blk| blk.call io }, :WTF?) do
       File.open "foo.txt", "r" do |f|
         rs = f.write("woot")
@@ -1014,7 +1014,7 @@ class TestMinitestStub < Minitest::Test
 
     @assertion_count += 2
     rs = nil
-    io = StringIO.new "", "w"
+    io = StringIO.new(+"", "w")
     @tc.assert_raises ArgumentError do
       File.stub6_2(:open, lambda { |p, m, &blk| blk.call io }, :WTF?) do
         File.open "foo.txt", "r" do |f|
@@ -1064,7 +1064,7 @@ class TestMinitestStub < Minitest::Test
   def test_stub_value_block_args_5
     @assertion_count += 2
     rs = nil
-    io = StringIO.new "", "w"
+    io = StringIO.new(+"", "w")
     File.stub5 :open, :value, io do
       result = File.open "foo.txt", "r" do |f|
         rs = f.write("woot")
@@ -1092,7 +1092,7 @@ class TestMinitestStub < Minitest::Test
 
     @assertion_count += 2
     rs = nil
-    io = StringIO.new "", "w"
+    io = StringIO.new(+"", "w")
     assert_deprecated do
       File.stub6 :open, :value, io do
         result = File.open "foo.txt", "r" do |f|
@@ -1110,7 +1110,7 @@ class TestMinitestStub < Minitest::Test
 
     @assertion_count += 2
     rs = nil
-    io = StringIO.new "", "w"
+    io = StringIO.new(+"", "w")
     @tc.assert_raises ArgumentError do
       File.stub6_2 :open, :value, io do
         result = File.open "foo.txt", "r" do |f|

--- a/test/minitest/test_minitest_reporter.rb
+++ b/test/minitest/test_minitest_reporter.rb
@@ -31,7 +31,7 @@ class TestMinitestReporter < MetaMetaMetaTestCase
 
   def setup
     super
-    self.io = StringIO.new("")
+    self.io = StringIO.new(+"")
     self.r  = new_composite_reporter
   end
 

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -94,7 +94,7 @@ class TestMinitestUnit < MetaMetaMetaTestCase
       end
 
       def test_this_is_non_ascii_failure_message
-        fail 'ЁЁЁ'.force_encoding('ASCII-8BIT')
+        fail 'ЁЁЁ'.dup.force_encoding(Encoding::BINARY)
       end
     end
 


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205

Since `minitest` is tested as part of ruby-core CI, it needs to be compatible with the `--enable-frozen-string-literal` option.