### PR TITLE
ignore unused block

### DIFF
--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -816,7 +816,7 @@ class TestMinitestStub < Minitest::Test
   # [:value,  :block_call, :args] =>  N/A
 
   class Bar
-    def call
+    def call(&_) # to ignore unused block
       puts "hi"
     end
   end


### PR DESCRIPTION
The following error is raised with the patch: https://github.com/ruby/ruby/pull/10403

```
  1) Failure:
TestMinitestStub#test_stub_callable_block_5 [test/minitest/test_minitest_mock.rb:871]:
In stderr.
--- expected
+++ actual
@@ -1 +1,2 @@
-""
+"/home/ko1/ruby/minitest/lib/minitest/mock.rb:306: warning: the passed block for 'TestMinitestStub::Bar#call' defined at /home/ko1/ruby/minitest/test/minitest/test_minitest_mock.rb:819 may be ignored
+"
```

I'm not sure it is best patch but the failure will be removed. With this patch, we can merge https://github.com/ruby/ruby/pull/10403
