### PR TITLE
Add `-Werror` flag to turn Ruby warnings into errors

### DIFF
--- a/lib/minitest/error_on_warning.rb
+++ b/lib/minitest/error_on_warning.rb
@@ -1,0 +1,11 @@
+module Minitest
+
+  module ErrorOnWarning
+    def warn(message, category: nil)
+      message = "[#{category}] #{message}" if category
+      raise UnexpectedWarning, message
+    end
+  end
+
+  ::Warning.singleton_class.prepend(ErrorOnWarning)
+end


### PR DESCRIPTION
Fix: https://github.com/minitest/minitest/issues/990

When working on gems that support multiple Ruby versions, it can be tricky to noticed you introduced a warning as you generally develop locally with one specific version and rely on CI to ensure it still works on other Ruby versions.

I tested this manually with:

```ruby
require "minitest/autorun"

class FooTest < Minitest::Test
  def test_thing
    def some_method
    end
  end

  private
    def some_method
    end
end
```

```
$ ruby -Ilib /tmp/test.rb -Werror
Run options: -Werror --seed 4820

# Running:

W

Finished in 0.000317s, 3154.5710 runs/s, 0.0000 assertions/s.

  1) Warning:
FooTest#test_thing [/tmp/test.rb:11]:
/tmp/test.rb:11: warning: method redefined; discarding old some_method


1 runs, 0 assertions, 0 failures, 0 errors, 0 skips
```

Open questions:

  - I'm not too sure how to properly test this feature, It would need some sort of integration test with a dedicated process, but unless I missed it, there is no such style of test currently, so I'm a bit unsure how best to do it.
  - I'm not 100% sure how I should report warnings, should I count them as `error`, `failure`, or their own count?
