### PR TITLE
Idea for manually registering plugins

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -99,9 +99,9 @@ module Minitest
   end
 
   def self.init_plugins options # :nodoc:
-    self.extensions.each do |name|
+    self.extensions.each do |recv, name|
       msg = "plugin_#{name}_init"
-      send msg, options if self.respond_to? msg
+      recv.send msg, options if recv.respond_to? msg
     end
   end
 
@@ -119,8 +119,12 @@ module Minitest
       seen[name] = true
 
       require plugin_path
-      self.extensions << name
+      self.extensions << [self, name]
     end
+  end
+
+  def self.add_plugin plugin
+    self.extensions << [plugin, "mt"]
   end
 
   ##
@@ -257,9 +261,9 @@ module Minitest
         opts.separator ""
         opts.separator "Known extensions: #{extensions.join(", ")}"
 
-        extensions.each do |meth|
+        extensions.each do |recv, meth|
           msg = "plugin_#{meth}_options"
-          send msg, opts, options if self.respond_to?(msg)
+          recv.send msg, opts, options if recv.respond_to?(msg)
         end
       end
 

--- a/lib/minitest/pride_plugin.rb
+++ b/lib/minitest/pride_plugin.rb
@@ -1,27 +1,29 @@
 require "minitest"
 
 module Minitest
-  def self.plugin_pride_options opts, _options # :nodoc:
-    opts.on "-p", "--pride", "Pride. Show your testing pride!" do
-      PrideIO.pride!
-    end
-  end
-
-  def self.plugin_pride_init options # :nodoc:
-    if PrideIO.pride? then
-      klass = ENV["TERM"] =~ /^xterm|-256color$/ ? PrideLOL : PrideIO
-      io    = klass.new options[:io]
-
-      self.reporter.reporters.grep(Minitest::Reporter).each do |rep|
-        rep.io = io if rep.io.tty?
-      end
-    end
-  end
-
   ##
   # Show your testing pride!
 
   class PrideIO
+    Minitest.add_plugin self
+
+    def self.plugin_mt_options opts, _options # :nodoc:
+      opts.on "-p", "--pride", "Pride. Show your testing pride!" do
+        PrideIO.pride!
+      end
+    end
+
+    def self.plugin_mt_init options # :nodoc:
+      if PrideIO.pride? then
+        klass = ENV["TERM"] =~ /^xterm|-256color$/ ? PrideLOL : PrideIO
+        io    = klass.new options[:io]
+
+        Minitest.reporter.reporters.grep(Minitest::Reporter).each do |rep|
+          rep.io = io if rep.io.tty?
+        end
+      end
+    end
+
     ##
     # Activate the pride plugin. Called from both -p option and minitest/pride
 


### PR DESCRIPTION
This is just a straw man commit.  It introduces a method called `Minitest.add_plugin`.  You pass an object to `add_plugin` and that object is registered as a plugin.

This commit converts Minitest::PrideIO to use this interface, but that change is only for demonstration purposes.  The existing plugin infrastructure should be backwards compatible.

The advantages of this change are:

1. Plugins don't need to monkeypatch Minitest to register themselves
2. Plugins can manually be added (IOW we don't have to scan gems)

Here's a sample dummy test + plugin:

```ruby
require "minitest/autorun"

# This class would be distributed in a gem
module AaronPlugin
  def self.register!
    Minitest.add_plugin self
  end

  def self.plugin_mt_options opts, options
    # process options
    puts "processing some options"
  end

  def self.plugin_mt_init options
    # do init stuff
    puts "init call"
  end
end

# This could be called via something like:
#
# require "aaron_plugin/autorun"
#
# Or something like this:
#
# require "aaron_plugin"
# AaronPlugin.register!
#
# I'm just manually registering it here
AaronPlugin.register!

# Requiring pride plugin works as usual
require "minitest/pride_plugin"

class FooTest < Minitest::Test
  def test_foo
    assert true
  end
end
```

Running the above test looks like this:

<img width="1556" alt="Screenshot 2024-05-02 at 5 08 55 PM" src="https://github.com/minitest/minitest/assets/3124/239454ce-09f0-4f66-bc0b-e931fa255e35">

Note that PrideIO works the same, and both runs output the puts calls from my manually registered plugin.

Ref: https://github.com/minitest/minitest/issues/996