### PR TITLE
Fully qualify the Queue class to avoid conflicts with other libraries

### DIFF
--- a/lib/minitest/parallel.rb
+++ b/lib/minitest/parallel.rb
@@ -16,7 +16,7 @@ module Minitest
 
       def initialize size
         @size  = size
-        @queue = Queue.new
+        @queue = Thread::Queue.new
         @pool  = nil
       end
 


### PR DESCRIPTION
We have a minitest plugin that defines a module called `Queue`, so we weren't not able to use the parallel executor because the wrong Queue constant is being resolved in its initializer.

To make sure we are using the correct Queue class, we need to fully qualify it with `Thread::Queue`.

This matches how Ruby document the [Queue class in the standard library][1], and how [Ruby itself refer to it in the source code][2].

[1]: https://docs.ruby-lang.org/en/3.3/Thread/Queue.html
[2]: https://github.com/ruby/ruby/commit/4b298ad77a8388f0aae62daeca66659a8effeade