### PR TITLE
Accept colon style Hash#inspect in test

### DIFF
--- a/test/minitest/test_minitest_assertions.rb
+++ b/test/minitest/test_minitest_assertions.rb
@@ -141,10 +141,12 @@ class TestMinitestAssertions < Minitest::Test
     h1, h2 = {}, {}
     h1[1] = Object.new
     h2[1] = Object.new
+    invisible_hex_obj = Object.new
+    invisible_hex_obj.define_singleton_method(:inspect) { '#<Object:0xXXXXXX>' }
     msg = <<~EOM.chomp
            No visible difference in the Hash#inspect output.
            You should look at the implementation of #== on Hash or its members.
-           {1=>#<Object:0xXXXXXX>}
+           #{{ 1 => invisible_hex_obj }.inspect}
          EOM
 
     assert_triggered msg do

--- a/test/minitest/test_minitest_mock.rb
+++ b/test/minitest/test_minitest_mock.rb
@@ -276,7 +276,7 @@ class TestMinitestMock < Minitest::Test
 
     e = assert_raises(MockExpectationError) { mock.verify }
 
-    exp = "expected foo(:kw=>false) => nil, got [foo(:kw=>true) => nil]"
+    exp = "expected foo(#{{ :kw => false }.inspect.delete('{}')}) => nil, got [foo(#{{ :kw => true }.inspect.delete('{}')}) => nil]"
 
     assert_equal exp, e.message
   end
@@ -363,7 +363,7 @@ class TestMinitestMock < Minitest::Test
       mock.foo k1: arg1, k2: arg2, k3: :BAD!
     end
 
-    exp = "mocked method :foo failed block w/ [] {:k1=>:bar, :k2=>[1, 2, 3], :k3=>:BAD!}"
+    exp = "mocked method :foo failed block w/ [] #{{ :k1 => :bar, :k2 => [1, 2, 3], :k3 => :BAD! }.inspect}"
     assert_equal exp, e.message
   end
 
@@ -479,8 +479,8 @@ class TestMinitestMock < Minitest::Test
     e = assert_raises MockExpectationError do
       mock.foo k1: arg1, k2: :BAD!, k3: arg3
     end
-
-    assert_match(/unexpected keyword arguments.* vs .*:k2=>:BAD!/, e.message)
+    assert_match(/unexpected keyword arguments.* vs /, e.message)
+    assert_includes e.message, "vs #{{ :k1 => arg1, :k2 => :BAD!, :k3 => arg3 }.inspect}"
   end
 
   def test_mock_block_is_passed_function_block


### PR DESCRIPTION
`Hash#inspect` is proposed to change to `{key: value, non_symbol_key => value}` in https://bugs.ruby-lang.org/issues/20433#note-10
Pull request that change Hash#inspect is here https://github.com/ruby/ruby/pull/10924

This pull request makes test to accept `{key=>value}` style and the proposed `{key => value}` (space around `=>`) style and `{key: value}` style of `Hash#inspect`.