### PR TITLE
fix pride

### DIFF
--- a/lib/minitest/pride_plugin.rb
+++ b/lib/minitest/pride_plugin.rb
@@ -10,7 +10,7 @@ module Minitest
   def self.plugin_pride_init options # :nodoc:
     return unless PrideIO.pride?
 
-    klass = ENV["TERM"].match?(/^xterm|-256color$/) ? PrideLOL : PrideIO
+    klass = ENV["TERM"]&.match?(/^xterm|-256color$/) ? PrideLOL : PrideIO
     io    = klass.new options[:io]
 
     self.reporter.reporters.grep(Minitest::Reporter).each do |rep|


### PR DESCRIPTION
testing:

run
```
ruby -Ilib:test test/minitest/test_minitest_test.rb -p
```
with `TERM` set and unset and observe that all tests pass.

run `rake test`

fixes: #1009