### PR TITLE
Include class name in spec name

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -81,8 +81,9 @@ module Kernel
 
   def describe desc, *additional_desc, &block # :doc:
     stack = Minitest::Spec.describe_stack
-    name  = [stack.last, desc, *additional_desc].compact.join("::")
-    sclas = stack.last || if Class === self && kind_of?(Minitest::Spec::DSL) then
+    is_spec_class = Class === self && kind_of?(Minitest::Spec::DSL)
+    name  = [(self if stack.empty? && is_spec_class), stack.last, desc, *additional_desc].compact.join("::")
+    sclas = stack.last || if is_spec_class then
                             self
                           else
                             Minitest::Spec.spec_type desc, *additional_desc

--- a/test/minitest/test_minitest_spec.rb
+++ b/test/minitest/test_minitest_spec.rb
@@ -952,6 +952,23 @@ class TestMeta < MetaMetaMetaTestCase
     assert_equal "ExampleB::random_method", spec_b.name
   end
 
+  def test_name_inside_class
+    spec_a = nil
+    spec_b = nil
+    inside_class_example = Class.new Minitest::Spec
+    Object.const_set :InsideClassExample, inside_class_example
+    inside_class_example.class_eval do
+      spec_a = describe "a" do
+        spec_b = describe "b" do; end
+      end
+    end
+
+    assert_equal "InsideClassExample::a", spec_a.name
+    assert_equal "InsideClassExample::a::b", spec_b.name
+  ensure
+    Object.send :remove_const, :InsideClassExample
+  end
+
   def test_structure
     x, y, z, * = util_structure
 


### PR DESCRIPTION
This commit changes how spec names are generated to include the test class name. This makes it possible to target all the specs in a class using the `--name` flag.

For example:

```rb
class Foo < Minitest::Spec
  it "a"
  describe "b" do
    it "c"
  end
end
```

| Before | After |
| - | - |
| `Foo#test_0001_a` | `Foo#test_0001_a` |
| `b#test_0001_c` | `Foo::b#test_0001_c` |

Previously only the first spec would be matched by `--name /Foo/` but now they both are. This is also useful if there are multiple classes in the same file. We can select all of the `Bar` tests and none of the `Foo` tests by passing `--name /Bar/`:

```rb
class Foo < Minitest::Spec
  describe "a" do
    it "b"
    it "c"
  end
end

class Bar < Minitest::Spec
  describe "a" do
    it "b"
    it "c"
  end
end
```

Specs outside of classes are still named as before. These will still be named `a#test_0001_b` and `a#test_0001_c`:

```rb
describe "a" do
  it "b"
  it "c"
end
```

I implemented it by pulling out an `is_spec_class` variable and only including the class name if it's a spec class and if the describe stack is empty. It could maybe be a bit prettier but this was a small change.