### PR TITLE
pride: use true colors with *-direct terminals

### DIFF
--- a/lib/minitest/pride_plugin.rb
+++ b/lib/minitest/pride_plugin.rb
@@ -10,7 +10,7 @@ module Minitest
   def self.plugin_pride_init options # :nodoc:
     return unless PrideIO.pride?
 
-    klass = ENV["TERM"] =~ /^xterm|-256color$/ ? PrideLOL : PrideIO
+    klass = ENV["TERM"] =~ /^xterm|-(?:256color|direct)$/ ? PrideLOL : PrideIO
     io    = klass.new options[:io]
 
     self.reporter.reporters.grep(Minitest::Reporter).each do |rep|


### PR DESCRIPTION
ncurses uses the `-direct` suffix for terminals which natively support true color.  For instance, modern versions of Debian and Ubuntu contain the `tmux-direct` terminal type, which allow terminfo-using programs to detect the full range of true colors.  These are currently less commonly used, since they are new and many systems into which one might SSH don't yet support them, but they will become more common in the future with greater support.

However, the pride plugin does not detect these as supporting true color, since it only looks for terminals starting with `xterm` or ending in `-256color`.  As a result, the simpler color palette is used, which, while functional, is less stunning than the full rainbow palette.  To allow people using true color terminals to experience the full glory of pride mode, check the `TERM` definition to see if it ends in `-direct`, and if so, use the true color implementation.

Use a non-capturing group to minimize any performance impact or changes to capture variables since we don't require a capturing group.