### PR TITLE
Modify ancestors order to allow reaching `Minitest::Assertions#skipped`

### DIFF
--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -9,8 +9,8 @@ module Minitest
 
   class Test < Runnable
     require "minitest/assertions"
-    include Minitest::Assertions
     include Minitest::Reportable
+    include Minitest::Assertions
 
     def class_name # :nodoc:
       self.class.name # for Minitest::Reportable

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -157,6 +157,23 @@ class TestMinitestUnit < MetaMetaMetaTestCase
     refute_predicate test, :skipped?
   end
 
+  def test_skipped_is_reachable
+    test_class = Class.new FakeNamedTest do
+      def test_omg
+        skip
+      ensure
+        flunk unless skipped?
+      end
+    end
+
+    test = test_class.new :test_omg
+    test.run
+
+    refute_predicate test, :error?
+    refute_predicate test, :passed?
+    assert_predicate test, :skipped?
+  end
+
   def util_expand_bt bt
     bt.map { |f| f.start_with?(".") ? File.expand_path(f) : f }
   end


### PR DESCRIPTION
Hello 👋 , thanks for maintaining this gem ❤️ . I'd like to propose a change as calling `skipped?` in a test would result in a different output based on where it gets called. 

### Problem

  I'd like to be able to check if a test was skipped in a `ensure` block.

  ```ruby
  def test_something
    skip
  ensure
    puts skipped? #=> nil
  end
  ```

  This is currently not possible as `Minitest::Assertions#skipped?` is not reachable, it will instead reach `Minitest::Reportable#skipped?` which is implemented differently and always return `nil` in a `ensure` block since the test is not yet done and Minitest hasn't set any failures.

### Solution

  I figured the easiest way is to modify the ancestors order on `Minitest::Test` for `Assertions#skipped?` to have precedence.
