### PR TITLE
Support Ruby 3.2's Exception#detailed_message feature

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -1084,7 +1084,14 @@ module Minitest
     def message # :nodoc:
       bt = Minitest.filter_backtrace(self.backtrace).join("\n    ")
         .gsub(BASE_RE, "")
-      "#{self.error.class}: #{self.error.message}\n    #{bt}"
+      error_message = if self.error.respond_to?(:detailed_message)
+                        # detailed_message includes he error class name in parentheses
+                        # which we don't want since we're already including the class name
+                        self.error.detailed_message.sub(/ \(#{self.error.class}\)$/, '')
+                      else
+                        self.error.message
+                      end
+      "#{self.error.class}: #{error_message}\n    #{bt}"
     end
 
     def result_label # :nodoc:

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1371,4 +1371,27 @@ class TestUnexpectedError < Minitest::Test
           c
         EXP
   end
+
+  def test_detailed_message
+    skip "Ruby #{RUBY_VERSION} doesn't support Exception#detailed_message" unless 
+      Exception.instance_methods.include?(:detailed_message)
+
+    exception_class = Class.new(StandardError) do
+      def detailed_message(**options)
+        "Enhanced error message (#{self.class})"
+      end
+
+      def message
+        "Original message"
+      end
+    end
+
+    exception = exception_class.new
+    unexpected_error = Minitest::UnexpectedError.new(exception)
+
+    message = unexpected_error.message
+    assert_includes message, "Enhanced error message"
+    refute_includes message, "Original message"
+    refute_includes message, "(#{exception.class})"
+  end
 end


### PR DESCRIPTION
Ruby 3.2 introduced `Exception#detailed_message` to allow gems like `did_you_mean` and `error_highlight` to enrich exception messages. Previously, these gems modified `Exception#message`, which led to confusion in test suites that expected this message to follow a certain pattern. As a result of that change, Minitest stopped showing the enriched message, shown by default when running Ruby programs.

This commit updates Minitest to use `Exception#detailed_message` when available, falling back to message when not, ensuring enriched error messages are displayed without affecting test assertions.