### PR TITLE
Add serial (WASM friendly) executor.

### DIFF
--- a/lib/minitest/parallel.rb
+++ b/lib/minitest/parallel.rb
@@ -58,7 +58,7 @@ module Minitest
 
       module ClassMethods # :nodoc:
         def run_one_method klass, method_name, reporter
-          Minitest.parallel_executor << [klass, method_name, reporter]
+          Minitest.executor << [klass, method_name, reporter]
         end
 
         def test_order

--- a/lib/minitest/serial.rb
+++ b/lib/minitest/serial.rb
@@ -1,0 +1,23 @@
+module Minitest
+  module Serial # :nodoc:
+
+    ##
+    # The engine used to run multiple tests serially.
+
+    class Executor
+
+      ##
+      # Add a job to the queue
+      #
+      # In serial mode, the job is executed immediately.
+
+      def << work
+        klass, method, reporter = work
+        reporter.synchronize { reporter.prerecord klass, method }
+        result = Minitest.run_one_method klass, method
+        reporter.synchronize { reporter.record result }
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Hello, I was doing some experiments with Ruby WASM and the whole Ruby experience is ruined without proper TDD tooling. By default minitest doesn't work in WASM environment, since there is no implementation of Thread.

By moving to serial executor, I was able to run it in browser nativelly and I was again able to enjoy TDD.

<img width="860" height="319" alt="image" src="https://github.com/user-attachments/assets/47bbc527-add6-44ec-8b9c-dd5ea910db43" />

I'm not sure what's the best way to detect this. For now I have added serial executor and logic to pick it when 1 CPU is detected. That's what is detected in WASM environment. Happy to move to make it argument or non-automated switch.

I have renamed Minitest.parallel_executor to Minitest.executor, no idea how backwards incompatible this is. Happy to deprecated parallel_executor first or keep the name as is.

Happy to add CI to run with MT_CPU=1 if welcomed to ensure coverage is full for both executors.