### PR TITLE
Relax to restrict upper version of Ruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Hoe.spec "minitest" do
 
   license "MIT"
 
-  require_ruby_version [">= 2.7", "< 4.0"]
+  require_ruby_version ">= 2.7"
 end
 
 desc "Find missing expectations"


### PR DESCRIPTION
Ruby 4.0 will be coming this year: https://github.com/ruby/ruby/commit/6d81969b475262aba251e99b518181bdf7c5a523

It means the current minitest couldn't use with Ruby 4.0 because minitest restrict `< 4.0` version at gemspec.

I relaxed to upper version.