### PR TITLE
Fix refute_in_epsilon to use min of abs values

### DIFF
--- a/lib/minitest/assertions.rb
+++ b/lib/minitest/assertions.rb
@@ -687,8 +687,8 @@ module Minitest
     # For comparing Floats.  Fails if +exp+ and +act+ have a relative error
     # less than +epsilon+.
 
-    def refute_in_epsilon a, b, epsilon = 0.001, msg = nil
-      refute_in_delta a, b, a * epsilon, msg
+    def refute_in_epsilon exp, act, epsilon = 0.001, msg = nil
+      refute_in_delta exp, act, [exp.abs, act.abs].min * epsilon, msg
     end
 
     ##

--- a/test/minitest/test_minitest_assertions.rb
+++ b/test/minitest/test_minitest_assertions.rb
@@ -1280,10 +1280,14 @@ class TestMinitestAssertions < Minitest::Test
   end
 
   def test_refute_in_epsilon_triggered
-    assert_triggered "Expected |10000 - 9990| (10) to not be <= 10.0." do
-      @tc.refute_in_epsilon 10_000, 9990
+    assert_triggered "Expected |10000 - 9991| (9) to not be <= 9.991." do
+      @tc.refute_in_epsilon 10_000, 9991
       flunk
     end
+  end
+
+  def test_refute_in_epsilon_minimum
+    @tc.refute_in_epsilon 10_000, 9990
   end
 
   def test_refute_includes


### PR DESCRIPTION
`refute_in_epsilon` uses `a * epsilon` to calculate the delta threshold, while `assert_in_epsilon` ([source](https://github.com/minitest/minitest/blob/15265da64bd93cbed6c1eecb4a85c88329297e37/lib/minitest/assertions.rb#L247-L249)) uses `[exp.abs, act.abs].min * epsilon`. So the assert/refute pair are not consistent.

We updated `refute_in_epsilon` in `lib/minitest/assertions.rb` to use `[exp.abs, act.abs].min * epsilon`, and modified the test message to reflect correct delta calculation.