### PR TITLE
Fix reporter test shape variation warning

### DIFF
--- a/test/minitest/test_minitest_reporter.rb
+++ b/test/minitest/test_minitest_reporter.rb
@@ -29,10 +29,11 @@ class TestMinitestReporter < MetaMetaMetaTestCase
     super
     self.io = StringIO.new(+"")
     self.r  = new_composite_reporter
+    @et = @ft = @pt = @st = @sse = nil
   end
 
   def error_test
-    unless defined? @et then
+    unless @et then
       @et = FakeTest.new :woot
       @et.failures << Minitest::UnexpectedError.new(begin
                                                       raise "no"
@@ -45,7 +46,7 @@ class TestMinitestReporter < MetaMetaMetaTestCase
   end
 
   def system_stack_error_test
-    unless defined? @sse then
+    unless @sse then
 
       ex = SystemStackError.new
 
@@ -64,7 +65,7 @@ class TestMinitestReporter < MetaMetaMetaTestCase
   end
 
   def fail_test
-    unless defined? @ft then
+    unless @ft then
       @ft = FakeTest.new :woot
       @ft.failures <<   begin
                           raise Minitest::Assertion, "boo"
@@ -87,7 +88,7 @@ class TestMinitestReporter < MetaMetaMetaTestCase
   end
 
   def skip_test
-    unless defined? @st then
+    unless @st then
       @st = FakeTest.new :woot
       @st.failures << begin
                         raise Minitest::Skip


### PR DESCRIPTION
Running `ruby -W:performance -Ilib:test test/minitest/test_minitest_reporter.rb` on most often hits a random test order that produces a performance warning in Ruby 4. This nit fix just defines instance variables up front so the order is static, avoiding intermittent performance warnings when tests are run.

```
ruby -W:performance -Ilib:test test/minitest/test_minitest_reporter.rb
Run options: --seed 57373

# Running:

...............test/minitest/test_minitest_reporter.rb:68: warning: The class TestMinitestReporter reached 8 shape variations, instance variables accesses will be slower and memory usage increased.
It is recommended to define instance variables in a consistent order, for instance by eagerly defining them all in the #initialize method.
.......
```