### PR TITLE
Explicitly call Runnable#run

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -464,7 +464,7 @@ module Minitest
           name = method_name
           t0 = Minitest.clock_time
 
-          run self, method_name, reporter
+          Runnable.run self, method_name, reporter
         end
       end
     end


### PR DESCRIPTION
When trying to run the test suite on v6 there is an error occurring around line 467. The issue seems to be that `run` belongs to the activesupport test class and there is a signature mismatch between the activesupport test case and the arguments being passed. It seems like the intent was to call `Runnable#run`. Making this change locally I was able to get my gem test suite to run as expected.