### PR TITLE
make prism a development dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ Hoe.spec "minitest" do
 
   require_ruby_version ">= 3.2"
 
-  dependency "prism", "~> 1.5"
+  dependency "prism", "~> 1.5", :development
 
   self.cov_filter = %w[ tmp ]
 end


### PR DESCRIPTION
Prism is a native gem and being a runtime dependency (in MT 6.0) breaks JRuby.

here's an example, trying to `bundle install` Rails 8.1 under JRuby 10.0.2.0:
```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
current directory:
/builds/build/.gems/10.0.2.0/gems/prism-1.7.0/ext/prism
/builds/backend/bin/jruby extconf.rb
extconf failedBad file descriptor - /bin/sh
Gem files will remain installed in
/builds/build/.relex-gems/10.0.2.0/gems/prism-1.7.0 for
inspection.
Results logged to
/builds/build/.gems/10.0.2.0/extensions/universal-java-21/3.4.0/prism-1.7.0/gem_make.out
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:102:in
'run'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/ext_conf_builder.rb:30:in
'build'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:206:in
'build_extension'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:240:in
'block in build_extensions'
  org/jruby/RubyArray.java:2088:in 'each'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:237:in
'build_extensions'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/installer.rb:844:in
'build_extensions'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:111:in
'build_extensions'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:30:in
'install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/source/rubygems.rb:220:in
'install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/gem_installer.rb:55:in
'install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/gem_installer.rb:17:in
'install_from_spec'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:133:in
'do_install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:124:in
'block in worker_pool'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:62:in
'apply_func'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:57:in
'block in process_queue'
  org/jruby/RubyKernel.java:1657:in 'loop'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:54:in
'process_queue'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:90:in
'block in create_threads'
An error occurred while installing prism (1.7.0), and Bundler cannot continue.
In Gemfile:
  rails was resolved to 8.1.1, which depends on
    actiontext was resolved to 8.1.1, which depends on
      action_text-trix was resolved to 2.1.16, which depends on
        railties was resolved to 8.1.1, which depends on
          actionpack was resolved to 8.1.1, which depends on
            actionview was resolved to 8.1.1, which depends on
              rails-dom-testing was resolved to 2.3.0, which depends on
                activesupport was resolved to 8.1.1, which depends on
                  minitest was resolved to 6.0.1, which depends on
                    prism
```