### PR TITLE
Validate incoming -W categories

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -225,7 +225,13 @@ module Minitest
           $VERBOSE = true
           ::Warning[:deprecated] = true
         else
-          ::Warning[s.to_sym] = true # check validity of category
+          if ::Warning.categories.include? s.to_sym then
+            ::Warning[s.to_sym] = true
+          else
+            warn "Unknown warning category: %p" % [s]
+            warn "Known categories: %s" % [::Warning.categories.join(", ")]
+            exit!
+          end
         end
       end
 


### PR DESCRIPTION
```
% bin/minitest -Wexperimental 1>/dev/null
% bin/minitest -Womg 1>/dev/null
Unknown warning category: "omg"
Known categories: deprecated, experimental, performance, strict_unused_block
zsh: exit 1     bin/minitest -Womg > /dev/null
```