### PR TITLE
Remove unnecessary executable bit and shebang

### DIFF
--- a/lib/minitest/find_minimal_combination.rb
+++ b/lib/minitest/find_minimal_combination.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/ruby -w
-
 ##
 # Finds the minimal combination of a collection of items that satisfy
 # +test+.

--- a/test/minitest/test_find_minimal_combination.rb
+++ b/test/minitest/test_find_minimal_combination.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/ruby -w
-
 $: << "." << "lib"
 
 require "minitest/autorun"


### PR DESCRIPTION
lib/minitest/find_minimal_combination.rb has an executable bit + a shebang, from a cursory view (few greps) over the codebase it does not seem necessary to have either, it seems to be used solely as a library file.