### PR TITLE
 Fix broken bisect feature

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ Hoe.spec "minitest" do
 
   require_ruby_version ">= 3.2"
 
+  dependency "drb", "~> 2.0"
   dependency "prism", "~> 1.5"
 
   self.cov_filter = %w[ tmp ]

--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -1225,3 +1225,4 @@ module Minitest
 end
 
 require_relative "minitest/test"
+Minitest.load :server

--- a/lib/minitest/server_plugin.rb
+++ b/lib/minitest/server_plugin.rb
@@ -1,5 +1,3 @@
-require_relative "../minitest"
-
 module Minitest
   @server = false
 


### PR DESCRIPTION
I tried `minitest --bisect` on `minitest` v6.0.1, but I got the `invalid option: --server` error.

```bash
$ MTB_VERBOSE=2 bundle exec minitest --bisect

/home/y-yagi/.rbenv/versions/3.4.4/bin/ruby -Itest:lib -e 'require "./test/test_helper.rb" ; require "./test/test_tester.rb"' -- --server 70268

reproducing...
invalid option: --server

Usage: rake test [A=options]        (see Minitest::TestTask for more options)
   or: minitest [paths] [options]   (with minitest-sprint gem)
   or: ruby path/to/test.rb [options]

    -h, --help                       Display this help.
    -s, --seed SEED                  Sets random seed. Also via env, eg: SEED=42
    -v, --verbose                    Verbose. Print each name as they run.
    -q, --quiet                      Quiet. Show no dots while processing files.
        --show-skips                 Show skipped at the end of run.
    -b, --bisect                     Run minitest in bisect-mode to isolate flaky tests.
    -i, --include PATTERN            Include /regexp/ or string for run.
    -e, --exclude PATTERN            Exclude /regexp/ or string from run.
    -S, --skip CODES                 Skip reporting of certain types of results (eg E).
    -W[error]                        Turn Ruby warnings into errors
 in 0.14 sec
Reproduction run passed? Aborting.
Try running with MTB_VERBOSE=2 to verify.
```


This is because `bisect` feature uses `minitest-server`, but `server_plugin` isn't loaded.

This commit loads the `server_plugin` by default to fix that.

This hasn't affect users who don't use `minitest-server` because `miniest-server` only enabes when passing `server` argument.
https://github.com/minitest/minitest/blob/d5c88428ffb3786c69e2a7c0c7619457cafd4d4d/lib/minitest/server_plugin.rb#L13-L16
