### PR TITLE
Document that test methods must be public

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -420,7 +420,8 @@ module Minitest
     end
 
     ##
-    # Returns all instance methods matching the pattern +re+.
+    # Returns all public instance methods matching the pattern +re+.
+    # Methods with private or protected visibility are excluded.
 
     def self.methods_matching re
       public_instance_methods(true).grep(re).map(&:to_s)

--- a/lib/minitest/test.rb
+++ b/lib/minitest/test.rb
@@ -106,9 +106,10 @@ module Minitest
     end
 
     ##
-    # Returns all instance methods starting with "test_". Based on
-    # #run_order, the methods are either sorted, randomized
-    # (default), or run in parallel.
+    # Returns all public instance methods starting with "test_".
+    # Methods with private or protected visibility are excluded,
+    # so they are not run as tests. Based on #run_order, the methods
+    # are either sorted, randomized (default), or run in parallel.
 
     def self.runnable_methods
       methods = methods_matching(/^test_/)

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1054,6 +1054,23 @@ class TestMinitestTestAssertions < Minitest::Test
     assert_equal expected, sample_test_case.runnable_methods
   end
 
+  def test_runnable_methods_skips_non_public_methods
+    @assertion_count = 0
+
+    sample_test_case = Class.new FakeNamedTest do
+      def self.run_order; :sorted end
+      def test_public; assert "does not matter" end
+      private
+      def test_private; assert "does not matter" end
+    end
+    sample_test_case.class_eval do
+      protected
+      def test_protected; assert "does not matter" end
+    end
+
+    assert_equal %w[test_public], sample_test_case.runnable_methods
+  end
+
   def test_i_suck_and_my_tests_are_order_dependent_bang_sets_run_order_alpha
     @assertion_count = 0
 


### PR DESCRIPTION
As confirmed in https://github.com/rubocop/rubocop-minitest/pull/229, there are real-world cases where non-public methods whose names start with `test_` are silently skipped. This PR clarifies the documentation to make it explicit to users that test methods must be public.

`Minitest::Runnable.methods_matching` uses `public_instance_methods`, so private and protected test_ methods are silently skipped. The behavior was previously implemented but neither documented nor covered by tests, which meant users could accidentally hide tests by changing the visibility of a test method without any signal from the framework.

Clarify the RDoc for both methods_matching and
`Minitest::Test.runnable_methods`. Additionally, since there was no test case for this behavior, add a regression test that locks in the documented behavior so that the visibility filter cannot be accidentally relaxed in the future.