### PR TITLE
Drop ruby2_keywords delegation workaround

### DIFF
--- a/lib/minitest/spec.rb
+++ b/lib/minitest/spec.rb
@@ -5,23 +5,18 @@ class Module # :nodoc:
     block = dont_flip == :block
     dont_flip = false if block
 
-    # https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html
-    # Drop this when we can drop ruby 2.6 (aka after rails 6.1 EOL, ~2024-06)
-    kw_extra = "ruby2_keywords %p" % [new_name] if respond_to? :ruby2_keywords, true
-
     self.class_eval <<-EOM, __FILE__, __LINE__ + 1
-      def #{new_name} *args
+      def #{new_name}(*args, **kws)
         raise "Calling ##{new_name} outside of test." unless ctx
         case
         when #{!!dont_flip} then
-          ctx.#{meth}(target, *args)
+          ctx.#{meth}(target, *args, **kws)
         when #{block} && Proc === target then
-          ctx.#{meth}(*args, &target)
+          ctx.#{meth}(*args, **kws, &target)
         else
-          ctx.#{meth}(args.first, target, *args[1..-1])
+          ctx.#{meth}(args.first, target, *args[1..-1], **kws)
         end
       end
-      #{kw_extra}
     EOM
   end
 end


### PR DESCRIPTION
As minitest now requires Ruby >= 3.2, the ruby2_keywords shim added for
Ruby 2.6 compatibility is no longer needed. We can now forward keyword
arguments explicitly with `**kws` instead, preserving the existing block
handling where only the `:block` branch passes `&target`.