### PR TITLE
Add Minitest.autorun_installed? and Minitest.completed? predicates

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -13,6 +13,7 @@ module Minitest
   VERSION = "6.0.6" # :nodoc:
 
   @@installed_at_exit ||= false
+  @@completed ||= false
   @@after_run = []
   @extensions = []
 
@@ -94,6 +95,40 @@ module Minitest
 
   def self.after_run &block
     @@after_run << block
+  end
+
+  ##
+  # Returns true once +Minitest.autorun+ has registered its +at_exit+
+  # hook. The hook is only installed once; subsequent +autorun+ calls
+  # are no-ops, but this predicate stays true.
+  #
+  # Useful for outside libraries that need to know whether
+  # +Minitest.run+ is scheduled to run later in the +at_exit+ chain
+  # (e.g. via +require "minitest/autorun"+) so they can defer their
+  # own work through +Minitest.after_run+ instead of fighting the
+  # +at_exit+ LIFO ordering.
+  #
+  # See also +Minitest.completed?+ and
+  # https://github.com/simplecov-ruby/simplecov/issues/1032.
+
+  def self.autorun_installed?
+    @@installed_at_exit
+  end
+
+  ##
+  # Returns true once +Minitest.run+ has finished a suite (whether
+  # the run passed, failed, or was interrupted past the report phase).
+  # Returns false before the first run completes.
+  #
+  # Pairs with +autorun_installed?+ to answer "is Minitest going to
+  # run tests after my +at_exit+ fires?" — that's
+  # +autorun_installed? && !completed?+.
+  #
+  # See also +Minitest.autorun_installed?+ and
+  # https://github.com/simplecov-ruby/simplecov/issues/1032.
+
+  def self.completed?
+    @@completed
   end
 
   ##
@@ -324,6 +359,8 @@ module Minitest
     summary = reporter.reporters.grep(SummaryReporter).first
 
     reporter.report
+
+    @@completed = true
 
     return empty_run! options if finished && summary && summary.count == 0
     finished and reporter.passed?

--- a/test/minitest/test_minitest_test.rb
+++ b/test/minitest/test_minitest_test.rb
@@ -1315,3 +1315,86 @@ class TestUnexpectedError < Minitest::Test
         EXP
   end
 end
+
+##
+# Exercises +Minitest.autorun_installed?+ and +Minitest.completed?+
+# plus the +@@completed+ flag they expose. These tests mutate
+# Minitest-level class variables, so the class is NOT parallelized;
+# each test saves and restores the flags it touches.
+#
+# See https://github.com/simplecov-ruby/simplecov/issues/1032 for the
+# external use case driving these predicates.
+
+class TestMinitestLifecyclePredicates < Minitest::Test
+  def setup
+    super
+    @prev_installed = Minitest.class_variable_get(:@@installed_at_exit)
+    @prev_completed = Minitest.class_variable_get(:@@completed)
+  end
+
+  def teardown
+    Minitest.class_variable_set(:@@installed_at_exit, @prev_installed)
+    Minitest.class_variable_set(:@@completed, @prev_completed)
+    super
+  end
+
+  def set_state installed_at_exit:, completed:
+    Minitest.class_variable_set(:@@installed_at_exit, installed_at_exit)
+    Minitest.class_variable_set(:@@completed, completed)
+  end
+
+  def test_autorun_installed_eh_reflects_installed_at_exit_class_variable
+    set_state installed_at_exit: true, completed: false
+    assert Minitest.autorun_installed?
+
+    set_state installed_at_exit: false, completed: false
+    refute Minitest.autorun_installed?
+  end
+
+  def test_completed_eh_reflects_completed_class_variable
+    set_state installed_at_exit: true, completed: true
+    assert Minitest.completed?
+
+    set_state installed_at_exit: true, completed: false
+    refute Minitest.completed?
+  end
+
+  def test_predicates_are_independent_of_each_other
+    set_state installed_at_exit: true, completed: false
+    assert Minitest.autorun_installed?
+    refute Minitest.completed?
+
+    set_state installed_at_exit: false, completed: true
+    refute Minitest.autorun_installed?
+    assert Minitest.completed?
+  end
+
+  def test_completed_eh_is_false_during_active_run
+    # We're inside `Minitest.run` while this test executes — the
+    # `@@completed` flag isn't set until the run finishes emitting
+    # its report, so the live state should report not-yet-completed.
+    refute Minitest.completed?
+  end
+
+  def test_run_sets_completed_to_true_in_subprocess
+    skip "windows doesn't have fork" unless Process.respond_to? :fork
+
+    read_io, write_io = IO.pipe
+    pid = fork do
+      read_io.close
+      # Clear runnables in the child so `Minitest.run` doesn't try to
+      # re-execute the parent suite (including this test). We only
+      # need to drive the run pipeline through to the `@@completed`
+      # assignment.
+      Minitest::Runnable.runnables.clear
+      capture_io { Minitest.run %w[--seed 42] }
+      write_io.write Minitest.completed? ? "1" : "0"
+    end
+    write_io.close
+    Process.waitpid pid
+    assert_equal "1", read_io.read
+  ensure
+    read_io&.close
+    write_io&.close
+  end
+end


### PR DESCRIPTION
Exposes two pieces of lifecycle state that previously required reaching into the `@@installed_at_exit` class variable:

* `Minitest.autorun_installed?` — public accessor for `@@installed_at_exit` that returns `true` once `Minitest.autorun` has registered its `at_exit` hook.
* `Minitest.completed?` — returns `true` once `Minitest.run` has finished a suite.

Together they answer "is Minitest going to run tests after my at_exit fires?" via `autorun_installed? && !completed?`, which lets outside libraries with their own `at_exit` hooks (e.g. coverage tools loaded after `minitest/autorun`) decide whether to defer their work through `Minitest.after_run` instead of fighting the `at_exit` LIFO ordering.

Adds a `@@completed` class variable that `Minitest.run` flips to `true` after the report is emitted, alongside the existing `@@installed_at_exit`.

This is an alternate proposal to https://github.com/minitest/minitest/pull/1075, but you could merge both.

References https://github.com/simplecov-ruby/simplecov/issues/1032.