### PR TITLE
Make links in readme relative so they work on minite.st too

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -93,7 +93,7 @@ Given that you'd like to test the following class:
 === Unit tests
 
 Define your tests as methods beginning with +test_+. Use
-{assertions}[/minitest/Minitest/Assertions.html] to test for results
+{assertions}[./Minitest/Assertions.html] to test for results
 or state.
 
   require "minitest/autorun"
@@ -118,7 +118,7 @@ or state.
 
 === Specs
 
-Use {expectations}[/minitest/Minitest/Expectations.html] to check
+Use {expectations}[./Minitest/Expectations.html] to check
 results or state. They must be wrapped in a value call (eg +_+).
 
   require "minitest/autorun"
@@ -148,7 +148,7 @@ For matchers support check out:
 
 === Benchmarks
 
-Add {benchmarks}[/minitest/Minitest/Benchmark.html] to your tests.
+Add {benchmarks}[./Minitest/Benchmark.html] to your tests.
 
   # optionally run benchmarks, good for CI-only work!
   require "minitest/benchmark" if ENV["BENCH"]


### PR DESCRIPTION
These three links don't work on [minite.st docs](https://minite.st/docs/). I'm no expert on rdoc, but I would expect relative links to work, both here and on https://docs.seattlerb.org/minitest/README_rdoc.html